### PR TITLE
Add expires_at column to the personal_access_tokens table

### DIFF
--- a/database/migrations/2023_02_14_183105_add_expires_at_to_token_table.php
+++ b/database/migrations/2023_02_14_183105_add_expires_at_to_token_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddExpiresAtToTokenTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('personal_access_tokens', function (Blueprint $table): void {
+            $table->dateTime('expires_at')
+                ->nullable()
+                ->after('abilities');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('personal_access_tokens', function (Blueprint $table): void {
+            $table->dropColumn('expires_at');
+        });
+    }
+}


### PR DESCRIPTION
Trying to create an API token fails because it's missing the column.