### PR TITLE
Rearrange the order of the Composer scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,11 +74,12 @@
     },
     "scripts": {
         "all": [
-            "@coverage",
+            "@lint",
             "@phpcs",
             "@php-cs-fixer",
             "@phpstan",
-            "@psalm"
+            "@psalm",
+            "@coverage"
         ],
         "coverage": [
             "Composer\\Config::disableProcessTimeout",


### PR DESCRIPTION
Run them in an order more likely to catch serious problems before PHPUnit since tests take so long to run.