### PR TITLE
Update Composer script to not ignore env

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,7 @@
         ],
         "infection": "infection --coverage=public/coverage",
         "lint": "parallel-lint --colors app config data tests",
-        "php-cs-fixer": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix --dry-run --config=php_cs.php -v --diff",
+        "php-cs-fixer": "php-cs-fixer fix --dry-run --config=php_cs.php -v --diff",
         "phpcs": "phpcs -p --colors --cache",
         "phpmnd": "phpmnd --progress app",
         "phpstan": [


### PR DESCRIPTION
The issue seems to have been fixed upstream.