### PR TITLE
Add env variable for Sanctum config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
+SANCTUM_STATEFUL_DOMAINS="localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1,commlink.digitaldarkness.com"
 
 AVATAR_DATA_PATH=data/Avatar/
 CAPERS_DATA_PATH=data/Capers/


### PR DESCRIPTION
Without adding the hostname, calls to the API from the frontend fail.