### PR TITLE
Standardize PHPUnit group annotations

### DIFF
--- a/tests/Feature/Http/Controllers/StarTrekAdventures/CharactersControllerTest.php
+++ b/tests/Feature/Http/Controllers/StarTrekAdventures/CharactersControllerTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Medium;
 use Tests\TestCase;
 
-#[Group('star-trek-adventures')]
+#[Group('startrekadventures')]
 #[Medium]
 final class CharactersControllerTest extends TestCase
 {

--- a/tests/Feature/Models/StarTrekAdventures/CharacterTest.php
+++ b/tests/Feature/Models/StarTrekAdventures/CharacterTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Small;
 use Tests\TestCase;
 
-#[Group('star-trek-adventures')]
+#[Group('startrekadventures')]
 #[Small]
 final class CharacterTest extends TestCase
 {

--- a/tests/Feature/Models/StarTrekAdventures/TalentArrayTest.php
+++ b/tests/Feature/Models/StarTrekAdventures/TalentArrayTest.php
@@ -12,7 +12,7 @@ use Tests\TestCase;
 use TypeError;
 use stdClass;
 
-#[Group('star-trek-adventures')]
+#[Group('startrekadventures')]
 #[Small]
 final class TalentArrayTest extends TestCase
 {

--- a/tests/Feature/Models/StarTrekAdventures/TalentTest.php
+++ b/tests/Feature/Models/StarTrekAdventures/TalentTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\Attributes\Small;
 use RuntimeException;
 use Tests\TestCase;
 
-#[Group('star-trek-adventures')]
+#[Group('startrekadventures')]
 #[Small]
 final class TalentTest extends TestCase
 {

--- a/tests/Feature/Models/StarTrekAdventures/TraitsTest.php
+++ b/tests/Feature/Models/StarTrekAdventures/TraitsTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\Attributes\Small;
 use RuntimeException;
 use Tests\TestCase;
 
-#[Group('star-trek-adventures')]
+#[Group('startrekadventures')]
 #[Small]
 final class TraitsTest extends TestCase
 {

--- a/tests/Feature/Rolls/StarTrekAdventures/ChallengeTest.php
+++ b/tests/Feature/Rolls/StarTrekAdventures/ChallengeTest.php
@@ -15,7 +15,7 @@ use function json_decode;
 
 use const PHP_EOL;
 
-#[Group('star-trek-adventures')]
+#[Group('startrekadventures')]
 #[Medium]
 final class ChallengeTest extends TestCase
 {

--- a/tests/Feature/Rolls/StarTrekAdventures/FocusedTest.php
+++ b/tests/Feature/Rolls/StarTrekAdventures/FocusedTest.php
@@ -13,7 +13,7 @@ use Tests\TestCase;
 
 use const PHP_EOL;
 
-#[Group('star-trek-adventures')]
+#[Group('startrekadventures')]
 #[Medium]
 final class FocusedTest extends TestCase
 {

--- a/tests/Feature/Rolls/StarTrekAdventures/HelpTest.php
+++ b/tests/Feature/Rolls/StarTrekAdventures/HelpTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Medium;
 use Tests\TestCase;
 
-#[Group('star-trek-adventures')]
+#[Group('startrekadventures')]
 #[Medium]
 final class HelpTest extends TestCase
 {

--- a/tests/Feature/Rolls/StarTrekAdventures/UnfocusedTest.php
+++ b/tests/Feature/Rolls/StarTrekAdventures/UnfocusedTest.php
@@ -15,7 +15,7 @@ use function json_decode;
 
 use const PHP_EOL;
 
-#[Group('star-trek-adventures')]
+#[Group('startrekadventures')]
 #[Medium]
 final class UnfocusedTest extends TestCase
 {

--- a/tests/Feature/Services/WorldAnvil/CyberpunkRedConverterTest.php
+++ b/tests/Feature/Services/WorldAnvil/CyberpunkRedConverterTest.php
@@ -16,7 +16,7 @@ use function implode;
 
 use const DIRECTORY_SEPARATOR;
 
-#[Group('cyberpunk-red')]
+#[Group('cyberpunkred')]
 #[Group('world-anvil')]
 #[Medium]
 final class CyberpunkRedConverterTest extends TestCase


### PR DESCRIPTION
For RPG systems, the group name should match their short code.