### PR TITLE
Fix creating characters for modules without character classes

### DIFF
--- a/app/Models/Character.php
+++ b/app/Models/Character.php
@@ -12,6 +12,7 @@ use MongoDB\Laravel\Eloquent\Model;
 use Nwidart\Modules\Facades\Module;
 use Stringable;
 
+use function class_exists;
 use function ucfirst;
 
 /**
@@ -94,24 +95,23 @@ class Character extends Model implements Stringable
         $attributes = [],
         $connection = null,
     ): Character {
+        $class = 'Modules\\' . ucfirst($attributes['system'])
+            . '\\Models\\Character';
         if (
             null !== Module::find($attributes['system'])
             && Module::isEnabled($attributes['system'])
+            && class_exists($class)
         ) {
-            $character = 'Modules\\' . ucfirst($attributes['system']) . '\\Models\\Character';
-            $character = new $character($attributes);
+            /** @var Character */
+            $character = new $class($attributes);
         } else {
             $character = new Character($attributes);
         }
-        // @phpstan-ignore-next-line
         $character->exists = true;
-        // @phpstan-ignore-next-line
         $character->setRawAttributes($attributes, true);
-        // @phpstan-ignore-next-line
         $character->setConnection($this->connection);
-        // @phpstan-ignore-next-line
         $character->fireModelEvent('retrieved', false);
-        // @phpstan-ignore-next-line
+        // @phpstan-ignore return.type
         return $character;
     }
 }

--- a/app/Rolls/Help.php
+++ b/app/Rolls/Help.php
@@ -8,8 +8,14 @@ use App\Http\Responses\Slack\SlackResponse;
 use App\Models\Channel;
 use App\Models\Slack\TextAttachment;
 
+use function config;
+use function sprintf;
+use function str_replace;
+
+use const PHP_EOL;
+
 /**
- * @psalm-suppress UnusedClass
+ * @psalm-api
  */
 class Help extends Roll
 {
@@ -29,44 +35,44 @@ class Help extends Roll
         parent::__construct($content, $character, $channel);
         $this->data[] = [
             'color' => TextAttachment::COLOR_INFO,
-            'discordText' => \sprintf(
+            'discordText' => sprintf(
                 '%1$s is a Discord bot that lets you roll dice appropriate for '
                     . 'various RPG systems. For example, if you are playing '
                     . 'The Expanse, it will roll three dice, marking one of '
                     . 'them as the "drama die", adding up the result with the '
                     . 'number you give for your attribute+focus score, and '
                     . 'return the result along with any stunt points.'
-                    . \PHP_EOL . \PHP_EOL
+                    . PHP_EOL . PHP_EOL
                     . 'If your game uses the web app for %1$s (%2$s) as well, '
                     . 'links in the app will automatically roll in Discord, '
                     . 'and changes made to your character via Discord will '
-                    . 'appear in %1$s.' . \PHP_EOL . \PHP_EOL,
+                    . 'appear in %1$s.' . PHP_EOL . PHP_EOL,
                 config('app.name'),
                 config('app.url'),
             ),
-            'ircText' => \sprintf(
+            'ircText' => sprintf(
                 '%1$s is an IRC bot that lets you roll dice appropriate for '
                     . 'various RPG systems. For example, if you are playing '
                     . 'The Expanse, it will roll three dice, marking one of '
                     . 'them as the "drama die", adding up the result with the '
                     . 'number you give for your attribute+focus score, and '
                     . 'return the result along with any stunt points.'
-                    . \PHP_EOL . \PHP_EOL
+                    . PHP_EOL . PHP_EOL
                     . 'If your game uses the web app for %1$s (%2$s) as well, '
                     . 'links in the app will automatically roll in IRC, '
                     . 'and changes made to your character via Discord will '
-                    . 'appear in %1$s.' . \PHP_EOL,
+                    . 'appear in %1$s.' . PHP_EOL,
                 config('app.name'),
                 config('app.url'),
             ),
-            'slackText' => \sprintf(
+            'slackText' => sprintf(
                 '%1$s is a Slack bot that lets you roll dice appropriate for '
                     . 'various RPG systems. For example, if you are playing '
                     . 'The Expanse, it will roll three dice, marking one of '
                     . 'them as the "drama die", adding up the result with the '
                     . 'number you give for your attribute+focus score, and '
                     . 'return the result along with any stunt points.'
-                    . \PHP_EOL . \PHP_EOL . 'If your game uses the web app for '
+                    . PHP_EOL . PHP_EOL . 'If your game uses the web app for '
                     . '<%2$s|%1$s> as well, links in the app will '
                     . 'automatically roll in Slack, and changes made to your '
                     . 'character via Slack will appear in %1$s.',
@@ -88,8 +94,8 @@ class Help extends Roll
     {
         $value = '';
         foreach ($this->data as $element) {
-            $value .= \sprintf('**%s**', $element['title']) . \PHP_EOL
-                . ($element['discordText'] ?? $element['text']) . \PHP_EOL;
+            $value .= sprintf('**%s**', $element['title']) . PHP_EOL
+                . ($element['discordText'] ?? $element['text']) . PHP_EOL;
         }
         return $value;
     }
@@ -98,9 +104,9 @@ class Help extends Roll
     {
         $value = '';
         foreach ($this->data as $element) {
-            $value .= $element['title'] . \PHP_EOL
+            $value .= $element['title'] . PHP_EOL
                 . str_replace('`', '', $element['ircText'] ?? $element['text'])
-                . \PHP_EOL;
+                . PHP_EOL;
         }
         return $value;
     }
@@ -125,7 +131,7 @@ class Help extends Roll
     {
         $this->data[] = [
             'color' => TextAttachment::COLOR_DANGER,
-            'discordText' => \sprintf(
+            'discordText' => sprintf(
                 'Your Discord user has not been linked with a %s user. Go to '
                     . 'the settings page (%s/settings) and copy the command '
                     . 'listed there for this server. If the server isn\'t '
@@ -137,7 +143,7 @@ class Help extends Roll
                 $this->channel->server_id,
                 $this->channel->user,
             ),
-            'ircText' => \sprintf(
+            'ircText' => sprintf(
                 'Your IRC user has not been linked with a %s user. Go to '
                     . 'the settings page (%s/settings) and copy the command '
                     . 'listed there for this server. If the server isn\'t '
@@ -149,7 +155,7 @@ class Help extends Roll
                 $this->channel->server_id,
                 $this->channel->user,
             ),
-            'slackText' => \sprintf(
+            'slackText' => sprintf(
                 'Your Slack user has not been linked with a %s user. '
                     . 'Go to the <%s/settings|settings page> and copy the '
                     . 'command listed there for this server. If the server '
@@ -172,18 +178,18 @@ class Help extends Roll
     {
         $systems = [];
         foreach (config('app.systems') as $code => $name) {
-            $systems[] = \sprintf('%s (%s)', $code, $name);
+            $systems[] = sprintf('   · %s - %s', $code, $name);
         }
         $this->data[] = [
             'title' => 'Commands for unregistered channels:',
-            'text' => '· `help` - Show help' . \PHP_EOL
+            'text' => '· `help` - Show help' . PHP_EOL
                 . '· `XdY[+C] [text]` - Roll X dice with Y sides, '
                 . 'optionally adding C to the result, optionally '
-                . 'describing that the roll is for "text"' . \PHP_EOL
-                . '· `coin` - Flip a coin' . \PHP_EOL
+                . 'describing that the roll is for "text"' . PHP_EOL
+                . '· `coin` - Flip a coin' . PHP_EOL
                 . '· `register <system>` - Register this channel for '
-                . 'system code <system>, where system is one of: '
-                . implode(', ', $systems) . \PHP_EOL
+                . 'system code <system>, where system is one of:' . PHP_EOL
+                . implode(PHP_EOL, $systems) . PHP_EOL
                 . $this->getCampaignsHelp(),
             'color' => TextAttachment::COLOR_INFO,
         ];

--- a/database/factories/CharacterFactory.php
+++ b/database/factories/CharacterFactory.php
@@ -9,6 +9,10 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
 
+use function array_keys;
+use function config;
+use function in_array;
+
 /**
  * @extends Factory<Character>
  * @psalm-suppress UnusedClass
@@ -22,9 +26,11 @@ class CharacterFactory extends Factory
      * character.
      * @var array<int, string>
      */
-    protected array $usesHandle = [
+    protected array $uses_handle = [
         'cyberpunkred',
+        'shadowrunanarchy',
         'shadowrun5e',
+        'shadowrun6e',
     ];
 
     /**
@@ -39,7 +45,7 @@ class CharacterFactory extends Factory
             'name' => $name,
             'owner' => (string)(User::factory()->create())->email,
             'system' => (string)$this->faker->randomElement(
-                \array_keys((array)config('app.systems'))
+                array_keys((array)config('app.systems'))
             ),
         ];
     }
@@ -51,7 +57,7 @@ class CharacterFactory extends Factory
     public function configure(): CharacterFactory
     {
         $updateName = function (Model $character): void {
-            if (in_array($character->system, $this->usesHandle, true)) {
+            if (in_array($character->system, $this->uses_handle, true)) {
                 $character->name = null;
                 return;
             }


### PR DESCRIPTION
Tests are failing because the generic character factory uses the list of supported systems to create characters, but not all modules have a class for their character sheet.

Also some random cleanups, switching from using backslashes to imports and expanding the list of systems that use "handle" instead of "name" in the character factory.