### PR TITLE
Fix link to OpenAPI documentation, make it work in dev

### DIFF
--- a/public/openapi/swagger-initializer.js
+++ b/public/openapi/swagger-initializer.js
@@ -1,6 +1,6 @@
 window.onload = function() {
   window.ui = SwaggerUIBundle({
-    url: "https://commlink.digitaldarkness.com/openapi.yml",
+    url: "/openapi.yml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [

--- a/resources/views/settings.blade.php
+++ b/resources/views/settings.blade.php
@@ -318,7 +318,7 @@ use Laravel\Pennant\Feature;
                         <div class="accordion-body" id="api-keys-table">
                             <p>
                                 An API token is used to interact directly with
-                                <a href="https://app.swaggerhub.com/apis/omnicolor/Commlink">Commlink's API</a>.
+                                <a href="/openapi/index.html">{{ config('app.name') }}'s API</a>.
                                 If you're not a software developer or don't know
                                 what an API is, this probably isn't something
                                 that you need to use. In fact, unless you are


### PR DESCRIPTION
The link was going to the Swaggerhub documentation instead of the local copy. Also, since the full URL was specified in the initializer, it wouldn't work in dev.

Fixes #1744