### PR TITLE
Change to PHPUnit from artisan test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,7 @@
             "@lint-openapi"
         ],
         "coverage": [
-            "XDEBUG_MODE=coverage ./artisan test --parallel --coverage-html=public/coverage"
+            "XDEBUG_MODE=coverage phpunit --coverage-html=public/coverage"
         ],
         "infection": "infection --coverage=public/coverage",
         "lint": "parallel-lint --colors app config database routes tests Modules",


### PR DESCRIPTION
Running with artisan test was failing a bunch of random tests and creating temporary databases in the cwd.