### PR TITLE
Update PHP-cs-fixer to enforce the rule

### DIFF
--- a/Modules/Alien/app/Http/Requests/CreateSkillsRequest.php
+++ b/Modules/Alien/app/Http/Requests/CreateSkillsRequest.php
@@ -10,6 +10,8 @@ use Modules\Alien\Http\Controllers\CharactersController;
 use Modules\Alien\Models\PartialCharacter;
 use Modules\Alien\Models\Skill;
 
+use function in_array;
+
 class CreateSkillsRequest extends FormRequest
 {
     /**

--- a/Modules/Alien/app/Http/Resources/SkillResource.php
+++ b/Modules/Alien/app/Http/Resources/SkillResource.php
@@ -9,6 +9,8 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Modules\Alien\Models\Skill;
 
+use function count;
+
 /**
  * @mixin Skill
  */

--- a/Modules/Alien/app/Models/PartialCharacter.php
+++ b/Modules/Alien/app/Models/PartialCharacter.php
@@ -11,6 +11,7 @@ use Modules\Alien\Database\Factories\PartialCharacterFactory;
 use Stringable;
 
 use function array_key_exists;
+use function count;
 use function sprintf;
 
 /**

--- a/Modules/Alien/app/Models/Weapon.php
+++ b/Modules/Alien/app/Models/Weapon.php
@@ -8,6 +8,8 @@ use Override;
 use RuntimeException;
 use Stringable;
 
+use function sprintf;
+
 class Weapon implements Stringable
 {
     public const string RANGE_ENGAGED = 'engaged';

--- a/Modules/Alien/tests/Feature/Http/Controllers/CharactersControllerTest.php
+++ b/Modules/Alien/tests/Feature/Http/Controllers/CharactersControllerTest.php
@@ -17,6 +17,8 @@ use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
+use function assert;
+
 #[Group('alien')]
 #[Medium]
 final class CharactersControllerTest extends TestCase

--- a/Modules/Capers/app/Http/Requests/BoostsRequest.php
+++ b/Modules/Capers/app/Http/Requests/BoostsRequest.php
@@ -11,6 +11,9 @@ use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\In;
 use Modules\Capers\Models\PartialCharacter;
 
+use function count;
+use function sprintf;
+
 class BoostsRequest extends BaseRequest
 {
     /**

--- a/Modules/Capers/app/Models/Character.php
+++ b/Modules/Capers/app/Models/Character.php
@@ -15,6 +15,7 @@ use Modules\Capers\Database\Factories\CharacterFactory;
 use RuntimeException;
 
 use function array_search;
+use function sprintf;
 
 /**
  * Representation of a Capers character.

--- a/Modules/Capers/tests/Feature/Rolls/DrawTest.php
+++ b/Modules/Capers/tests/Feature/Rolls/DrawTest.php
@@ -14,6 +14,8 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Medium;
 use Tests\TestCase;
 
+use function sprintf;
+
 #[Group('capers')]
 #[Medium]
 final class DrawTest extends TestCase
@@ -186,7 +188,7 @@ final class DrawTest extends TestCase
         $response = (new Draw('draw guns', $channel->username, $channel))
             ->forDiscord();
         self::assertStringStartsWith(
-            \sprintf('%s drew the **', $channel->username),
+            sprintf('%s drew the **', $channel->username),
             $response
         );
         self::assertStringContainsString('for guns', $response);
@@ -239,7 +241,7 @@ final class DrawTest extends TestCase
         $response = (new Draw('draw guns', $channel->username, $channel))
             ->forIrc();
         self::assertStringStartsWith(
-            \sprintf('%s drew the ', $channel->username),
+            sprintf('%s drew the ', $channel->username),
             $response
         );
         self::assertStringContainsString('for guns', $response);

--- a/Modules/Cyberpunkred/app/Http/Controllers/CharactersController.php
+++ b/Modules/Cyberpunkred/app/Http/Controllers/CharactersController.php
@@ -21,6 +21,10 @@ use Modules\Cyberpunkred\Models\Character;
 use Modules\Cyberpunkred\Models\PartialCharacter;
 use Modules\Cyberpunkred\Models\Role;
 
+use function assert;
+use function count;
+use function sprintf;
+
 /**
  * Controller for interacting with Cyberpunk Red characters.
  */

--- a/Modules/Cyberpunkred/app/Models/TarotDeck.php
+++ b/Modules/Cyberpunkred/app/Models/TarotDeck.php
@@ -9,6 +9,9 @@ use Countable;
 use RuntimeException;
 use UnderflowException;
 
+use function assert;
+use function count;
+
 class TarotDeck extends Deck implements Countable
 {
     /**

--- a/Modules/Cyberpunkred/app/Rolls/Init.php
+++ b/Modules/Cyberpunkred/app/Rolls/Init.php
@@ -17,6 +17,7 @@ use function array_shift;
 use function count;
 use function explode;
 use function optional;
+use function sprintf;
 
 use const PHP_EOL;
 

--- a/Modules/Cyberpunkred/app/Rolls/Number.php
+++ b/Modules/Cyberpunkred/app/Rolls/Number.php
@@ -15,6 +15,7 @@ use function array_shift;
 use function array_sum;
 use function explode;
 use function implode;
+use function sprintf;
 
 use const PHP_EOL;
 

--- a/Modules/Cyberpunkred/app/Rolls/Tarot.php
+++ b/Modules/Cyberpunkred/app/Rolls/Tarot.php
@@ -13,7 +13,10 @@ use Exception;
 use Modules\Cyberpunkred\Models\TarotCard;
 use Modules\Cyberpunkred\Models\TarotDeck;
 
+use function assert;
+use function count;
 use function explode;
+use function sprintf;
 
 use const PHP_EOL;
 

--- a/Modules/Cyberpunkred/routes/api.php
+++ b/Modules/Cyberpunkred/routes/api.php
@@ -26,7 +26,7 @@ Route::middleware('auth:sanctum')
             } catch (RuntimeException) {
                 abort(
                     Response::HTTP_NOT_FOUND,
-                    sprintf('%s is not found', $armor),
+                    \sprintf('%s is not found', $armor),
                 );
             }
         })->name('armor.show');
@@ -44,7 +44,7 @@ Route::middleware('auth:sanctum')
             } catch (RuntimeException) {
                 abort(
                     Response::HTTP_NOT_FOUND,
-                    sprintf('%s is not found', $skill),
+                    \sprintf('%s is not found', $skill),
                 );
             }
         })->name('skills.show');
@@ -59,7 +59,7 @@ Route::middleware('auth:sanctum')
             } catch (RuntimeException) {
                 abort(
                     Response::HTTP_NOT_FOUND,
-                    sprintf('%s is not found', $weapon),
+                    \sprintf('%s is not found', $weapon),
                 );
             }
         })->name('weapons.show');

--- a/Modules/Cyberpunkred/tests/Feature/Rolls/HelpTest.php
+++ b/Modules/Cyberpunkred/tests/Feature/Rolls/HelpTest.php
@@ -14,6 +14,8 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Medium;
 use Tests\TestCase;
 
+use function sprintf;
+
 #[Group('cyberpunkred')]
 #[Medium]
 final class HelpTest extends TestCase

--- a/Modules/Cyberpunkred/tests/Feature/Rolls/InitTest.php
+++ b/Modules/Cyberpunkred/tests/Feature/Rolls/InitTest.php
@@ -21,6 +21,8 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Medium;
 use Tests\TestCase;
 
+use function sprintf;
+
 use const PHP_EOL;
 
 #[Group('cyberpunkred')]

--- a/Modules/Cyberpunkred/tests/Feature/Rolls/TarotTest.php
+++ b/Modules/Cyberpunkred/tests/Feature/Rolls/TarotTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Medium;
 use Tests\TestCase;
 
+use function sprintf;
+
 #[Group('cyberpunkred')]
 #[Medium]
 final class TarotTest extends TestCase
@@ -349,7 +351,7 @@ final class TarotTest extends TestCase
         $response = (new Tarot('tarot', $channel->username, $channel))
             ->forIrc();
         self::assertStringContainsString(
-            \sprintf('%s drew', $channel->username),
+            sprintf('%s drew', $channel->username),
             $response
         );
     }

--- a/Modules/Expanse/app/Http/Controllers/BackgroundsController.php
+++ b/Modules/Expanse/app/Http/Controllers/BackgroundsController.php
@@ -9,10 +9,12 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;
 use function sha1_file;
+use function sprintf;
 use function stat;
 use function strtolower;
 

--- a/Modules/Expanse/app/Http/Controllers/ConditionsController.php
+++ b/Modules/Expanse/app/Http/Controllers/ConditionsController.php
@@ -10,10 +10,12 @@ use Illuminate\Http\Response;
 use function array_key_exists;
 use function array_keys;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;
 use function sha1_file;
+use function sprintf;
 use function stat;
 use function strtolower;
 

--- a/Modules/Expanse/app/Http/Controllers/SocialClassesController.php
+++ b/Modules/Expanse/app/Http/Controllers/SocialClassesController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Response;
 use function array_key_exists;
 use function array_keys;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Expanse/app/Http/Controllers/TalentsController.php
+++ b/Modules/Expanse/app/Http/Controllers/TalentsController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Response;
 use function array_key_exists;
 use function array_keys;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Root/app/Models/Character.php
+++ b/Modules/Root/app/Models/Character.php
@@ -16,6 +16,7 @@ use Modules\Root\ValueObjects\Attribute;
 use Stringable;
 
 use function collect;
+use function is_array;
 use function json_decode;
 
 /**

--- a/Modules/Shadowrun5e/app/Http/Controllers/AdeptPowersController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/AdeptPowersController.php
@@ -10,6 +10,8 @@ use Illuminate\Http\Response;
 use function array_key_exists;
 use function array_keys;
 use function array_values;
+use function assert;
+use function count;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/AmmunitionController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/AmmunitionController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_keys;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/ArmorController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/ArmorController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_keys;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/ArmorModificationsController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/ArmorModificationsController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_keys;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/CharactersController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/CharactersController.php
@@ -38,7 +38,12 @@ use Rs\Json\Patch\InvalidPatchDocumentJsonException;
 use Rs\Json\Pointer\InvalidPointerException;
 use RuntimeException;
 
+use function array_key_exists;
 use function array_keys;
+use function array_slice;
+use function assert;
+use function count;
+use function in_array;
 use function sprintf;
 
 /**

--- a/Modules/Shadowrun5e/app/Http/Controllers/ComplexFormsController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/ComplexFormsController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/CritterPowersController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/CritterPowersController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Response;
 use function array_key_exists;
 use function array_keys;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/CritterWeaknessesController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/CritterWeaknessesController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Response;
 use function array_key_exists;
 use function array_keys;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/CrittersController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/CrittersController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Response;
 use function array_key_exists;
 use function array_keys;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/CyberwareController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/CyberwareController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/GearController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/GearController.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Auth;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/GearModificationsController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/GearModificationsController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/GruntsController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/GruntsController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Response;
 use function array_key_exists;
 use function array_keys;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/IntrusionCountermeasuresController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/IntrusionCountermeasuresController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Response;
 use function array_key_exists;
 use function array_keys;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/LifestyleOptionsController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/LifestyleOptionsController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/LifestyleZonesController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/LifestyleZonesController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/LifestylesController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/LifestylesController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Response;
 use function array_key_exists;
 use function array_keys;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/MartialArtsStylesController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/MartialArtsStylesController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/MartialArtsTechniquesController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/MartialArtsTechniquesController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/MentorSpiritsController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/MentorSpiritsController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/MetamagicsController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/MetamagicsController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/ProgramsController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/ProgramsController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/QualitiesController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/QualitiesController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function config;
 use function date;
 use function json_encode;

--- a/Modules/Shadowrun5e/app/Http/Controllers/ResonanceEchoesController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/ResonanceEchoesController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function config;
 use function date;
 use function json_encode;

--- a/Modules/Shadowrun5e/app/Http/Controllers/RulebooksController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/RulebooksController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Response;
 use function array_key_exists;
 use function array_keys;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/SkillsController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/SkillsController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/SpellsController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/SpellsController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/SpiritsController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/SpiritsController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/SpritesController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/SpritesController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/TraditionsController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/TraditionsController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/VehicleModificationsController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/VehicleModificationsController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/VehiclesController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/VehiclesController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Response;
 use function array_key_exists;
 use function array_keys;
 use function array_values;
+use function assert;
 use function config;
 use function date;
 use function json_encode;

--- a/Modules/Shadowrun5e/app/Http/Controllers/WeaponModificationsController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/WeaponModificationsController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function date;
 use function json_encode;
 use function sha1;

--- a/Modules/Shadowrun5e/app/Http/Controllers/WeaponsController.php
+++ b/Modules/Shadowrun5e/app/Http/Controllers/WeaponsController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 
 use function array_key_exists;
 use function array_values;
+use function assert;
 use function config;
 use function date;
 use function json_encode;

--- a/Modules/Shadowrun5e/app/Http/Requests/RulesRequest.php
+++ b/Modules/Shadowrun5e/app/Http/Requests/RulesRequest.php
@@ -10,6 +10,8 @@ use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\In;
 use Modules\Shadowrun5e\Models\Rulebook;
 
+use function in_array;
+
 class RulesRequest extends FormRequest
 {
     /**

--- a/Modules/Shadowrun5e/app/Http/Requests/StandardPriorityRequest.php
+++ b/Modules/Shadowrun5e/app/Http/Requests/StandardPriorityRequest.php
@@ -11,6 +11,11 @@ use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\In;
 use Illuminate\Validation\Rules\RequiredIf;
 
+use function chr;
+use function in_array;
+use function ord;
+use function sprintf;
+
 class StandardPriorityRequest extends FormRequest
 {
     /**

--- a/Modules/Shadowrun5e/app/Models/Augmentation.php
+++ b/Modules/Shadowrun5e/app/Models/Augmentation.php
@@ -9,6 +9,7 @@ use RuntimeException;
 use Stringable;
 
 use function config;
+use function is_int;
 use function sprintf;
 use function strtolower;
 

--- a/Modules/Shadowrun5e/app/Models/KarmaLog.php
+++ b/Modules/Shadowrun5e/app/Models/KarmaLog.php
@@ -21,6 +21,7 @@ use function ceil;
 use function count;
 use function current;
 use function in_array;
+use function is_int;
 use function key;
 use function number_format;
 use function sprintf;

--- a/Modules/Shadowrun5e/app/Models/Vehicle.php
+++ b/Modules/Shadowrun5e/app/Models/Vehicle.php
@@ -10,6 +10,7 @@ use Stringable;
 
 use function ceil;
 use function config;
+use function count;
 use function is_array;
 use function sprintf;
 use function str_contains;

--- a/Modules/Shadowrun5e/app/Models/VehicleModification.php
+++ b/Modules/Shadowrun5e/app/Models/VehicleModification.php
@@ -9,6 +9,7 @@ use Stringable;
 
 use function assert;
 use function config;
+use function is_array;
 use function sprintf;
 use function strtolower;
 

--- a/Modules/Shadowrun5e/app/Rolls/Init.php
+++ b/Modules/Shadowrun5e/app/Rolls/Init.php
@@ -17,6 +17,7 @@ use Modules\Shadowrun5e\Models\ForceTrait;
 use RuntimeException;
 
 use function array_shift;
+use function count;
 use function explode;
 use function implode;
 use function preg_match;

--- a/Modules/Shadowrun5e/app/View/Components/Powers.php
+++ b/Modules/Shadowrun5e/app/View/Components/Powers.php
@@ -11,6 +11,7 @@ use Modules\Shadowrun5e\Models\Character;
 use Modules\Shadowrun5e\Models\PartialCharacter;
 
 use function assert;
+use function in_array;
 
 class Powers extends Component
 {

--- a/Modules/Shadowrun6e/app/Models/Quality.php
+++ b/Modules/Shadowrun6e/app/Models/Quality.php
@@ -9,6 +9,7 @@ use RuntimeException;
 use Stringable;
 
 use function config;
+use function count;
 use function sprintf;
 use function strtolower;
 

--- a/Modules/Startrekadventures/app/Models/Character.php
+++ b/Modules/Startrekadventures/app/Models/Character.php
@@ -13,6 +13,8 @@ use Illuminate\Support\Facades\Log;
 use Modules\Startrekadventures\Database\Factories\CharacterFactory;
 use RuntimeException;
 
+use function is_array;
+
 /**
  * @property string $assignment
  * @property-read Disciplines $disciplines

--- a/Modules/Stillfleet/app/Http/Controllers/CharactersController.php
+++ b/Modules/Stillfleet/app/Http/Controllers/CharactersController.php
@@ -17,6 +17,7 @@ use Modules\Stillfleet\Models\PartialCharacter;
 use Modules\Stillfleet\Models\Role;
 
 use function abort;
+use function assert;
 use function count;
 use function route;
 use function view;

--- a/Modules/Subversion/app/Http/Controllers/CharactersController.php
+++ b/Modules/Subversion/app/Http/Controllers/CharactersController.php
@@ -35,6 +35,7 @@ use Modules\Subversion\Models\RelationLevel;
 use Modules\Subversion\Models\Skill;
 
 use function abort;
+use function array_key_exists;
 use function count;
 use function route;
 use function usort;

--- a/Modules/Subversion/app/Models/PartialCharacter.php
+++ b/Modules/Subversion/app/Models/PartialCharacter.php
@@ -10,6 +10,8 @@ use Modules\Subversion\Database\Factories\PartialCharacterFactory;
 use Override;
 use Stringable;
 
+use function count;
+
 /**
  * Representation of a character in character generation.
  * @method static self create(array<mixed, mixed> $attributes)

--- a/Modules/Subversion/app/Rolls/Number.php
+++ b/Modules/Subversion/app/Rolls/Number.php
@@ -12,6 +12,7 @@ use App\Rolls\Roll;
 use Facades\App\Services\DiceService;
 
 use function array_shift;
+use function array_slice;
 use function array_sum;
 use function explode;
 use function implode;

--- a/Modules/Transformers/app/Http/Controllers/CharactersController.php
+++ b/Modules/Transformers/app/Http/Controllers/CharactersController.php
@@ -19,6 +19,8 @@ use Modules\Transformers\Models\Character;
 use Modules\Transformers\Models\PartialCharacter;
 use Modules\Transformers\Models\Programming;
 
+use function count;
+
 class CharactersController extends Controller
 {
     protected const SESSION_KEY = 'transformers-partial';

--- a/Modules/Transformers/app/Models/AltMode.php
+++ b/Modules/Transformers/app/Models/AltMode.php
@@ -7,6 +7,7 @@ namespace Modules\Transformers\Models;
 use RuntimeException;
 use Stringable;
 
+use function in_array;
 use function ucfirst;
 
 readonly class AltMode implements Stringable

--- a/app/Console/Commands/ImportChummerData.php
+++ b/app/Console/Commands/ImportChummerData.php
@@ -26,6 +26,8 @@ use function explode;
 use function file_exists;
 use function file_put_contents;
 use function iconv;
+use function in_array;
+use function is_array;
 use function is_dir;
 use function ksort;
 use function min;

--- a/app/Console/Commands/ValidateDataFiles.php
+++ b/app/Console/Commands/ValidateDataFiles.php
@@ -11,6 +11,11 @@ use League\Flysystem\UnableToCreateDirectory;
 use Nwidart\Modules\Facades\Module;
 use ParseError;
 
+use function count;
+use function in_array;
+use function is_array;
+use function sprintf;
+
 /**
  * Test all data files for correctness.
  * @codeCoverageIgnore

--- a/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -10,6 +10,8 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 
+use function assert;
+
 class EmailVerificationNotificationController extends Controller
 {
     /**

--- a/app/Http/Controllers/DiscordController.php
+++ b/app/Http/Controllers/DiscordController.php
@@ -24,9 +24,11 @@ use Symfony\Component\HttpFoundation\RedirectResponse as SymfonyRedirectResponse
 use function assert;
 use function collect;
 use function count;
+use function is_array;
 use function redirect;
 use function session;
 use function sprintf;
+use function strlen;
 use function view;
 
 /**

--- a/app/Http/Controllers/HealthzController.php
+++ b/app/Http/Controllers/HealthzController.php
@@ -17,7 +17,9 @@ use function disk_free_space;
 use function disk_total_space;
 use function escapeshellarg;
 use function explode;
+use function in_array;
 use function shell_exec;
+use function sprintf;
 
 use const PHP_EOL;
 

--- a/app/Http/Controllers/SlackController.php
+++ b/app/Http/Controllers/SlackController.php
@@ -24,8 +24,10 @@ use Laravel\Socialite\Facades\Socialite;
 use Nwidart\Modules\Facades\Module;
 use Symfony\Component\HttpFoundation\RedirectResponse as SymfonyRedirectResponse;
 
+use function array_key_exists;
 use function explode;
 use function is_numeric;
+use function is_object;
 use function preg_match;
 use function sprintf;
 use function ucfirst;

--- a/app/Http/Controllers/VarzController.php
+++ b/app/Http/Controllers/VarzController.php
@@ -16,7 +16,10 @@ use League\Flysystem\UnableToCreateDirectory;
 use ParseError;
 use Throwable;
 
+use function array_key_exists;
 use function config;
+use function count;
+use function is_array;
 use function sprintf;
 use function ucwords;
 

--- a/app/Http/Responses/Slack/LinkResponse.php
+++ b/app/Http/Responses/Slack/LinkResponse.php
@@ -11,8 +11,10 @@ use App\Models\ChatCharacter;
 use App\Models\ChatUser;
 use App\Models\Slack\TextAttachment;
 
+use function assert;
 use function config;
 use function explode;
+use function sprintf;
 
 /**
  * Try to link a character to a Slack channel.

--- a/app/Mail/InvitedToCampaign.php
+++ b/app/Mail/InvitedToCampaign.php
@@ -12,6 +12,9 @@ use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 
+use function array_key_exists;
+use function sprintf;
+
 /**
  * @codeCoverageIgnore
  */

--- a/app/Models/Traits/GameSystem.php
+++ b/app/Models/Traits/GameSystem.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Models\Traits;
 
+use function array_key_exists;
+
 /**
  * Trait for changing the short system tag into the full system name.
  */

--- a/app/Rolls/Help.php
+++ b/app/Rolls/Help.php
@@ -9,6 +9,7 @@ use App\Models\Channel;
 use App\Models\Slack\TextAttachment;
 
 use function config;
+use function count;
 use function sprintf;
 use function str_replace;
 

--- a/app/Rolls/Rsvp.php
+++ b/app/Rolls/Rsvp.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 use function config;
+use function is_array;
 use function sprintf;
 
 class Rsvp extends Roll

--- a/app/Services/Chummer5/Shadowrun5eConverter.php
+++ b/app/Services/Chummer5/Shadowrun5eConverter.php
@@ -20,7 +20,10 @@ use Modules\Shadowrun5e\Models\Weapon;
 use RuntimeException;
 use SimpleXMLElement;
 
+use function array_key_exists;
 use function array_merge;
+use function count;
+use function sprintf;
 
 /**
  * Converter class to convert a Chummer 5 file to a Commlink Character.

--- a/app/Services/Omae/Shadowrun5eConverter.php
+++ b/app/Services/Omae/Shadowrun5eConverter.php
@@ -16,6 +16,9 @@ use Modules\Shadowrun5e\Models\Weapon;
 use Modules\Shadowrun5e\Models\WeaponModification;
 use RuntimeException;
 
+use function count;
+use function sprintf;
+
 use const FILE_IGNORE_NEW_LINES;
 use const FILE_SKIP_EMPTY_LINES;
 

--- a/app/Services/WorldAnvil/CyberpunkRedConverter.php
+++ b/app/Services/WorldAnvil/CyberpunkRedConverter.php
@@ -14,6 +14,7 @@ use Modules\Cyberpunkred\Models\Weapon;
 use RuntimeException;
 use stdClass;
 
+use function count;
 use function explode;
 use function sprintf;
 use function strtolower;

--- a/config/database.php
+++ b/config/database.php
@@ -41,7 +41,7 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => \extension_loaded('pdo_mysql') ? \array_filter([
+            'options' => \extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
@@ -60,7 +60,7 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
-            'options' => \extension_loaded('pdo_mysql') ? \array_filter([
+            'options' => \extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],

--- a/config/view.php
+++ b/config/view.php
@@ -23,6 +23,6 @@ return [
      */
     'compiled' => env(
         'VIEW_COMPILED_PATH',
-        \realpath(storage_path('framework/views'))
+        realpath(storage_path('framework/views'))
     ),
 ];

--- a/php_cs.php
+++ b/php_cs.php
@@ -71,6 +71,7 @@ $rules = [
         'strategy' => 'no_multi_line',
     ],
     'native_constant_invocation' => true,
+    'native_function_invocation' => true,
     'native_function_casing' => true,
     'new_with_parentheses' => true,
     'no_alias_functions' => true,

--- a/public/index.php
+++ b/public/index.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\Request;
 
-\define('LARAVEL_START', \microtime(true));
+\define('LARAVEL_START', microtime(true));
 
 /*
 |--------------------------------------------------------------------------
@@ -18,7 +18,7 @@ use Illuminate\Http\Request;
 |
 */
 
-if (\file_exists(__DIR__ . '/../storage/framework/maintenance.php')) {
+if (file_exists(__DIR__ . '/../storage/framework/maintenance.php')) {
     require __DIR__ . '/../storage/framework/maintenance.php';
 }
 

--- a/server.php
+++ b/server.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-$uri = \urldecode(\parse_url($_SERVER['REQUEST_URI'], \PHP_URL_PATH));
+$uri = urldecode(parse_url($_SERVER['REQUEST_URI'], \PHP_URL_PATH));
 
 // This file allows us to emulate Apache's "mod_rewrite" functionality from the
 // built-in PHP web server. This provides a convenient way to test a Laravel
 // application without having installed a "real" web server software here.
-if ('/' !== $uri && \file_exists(__DIR__ . '/public' . $uri)) {
+if ('/' !== $uri && file_exists(__DIR__ . '/public' . $uri)) {
     return false;
 }
 

--- a/tests/Feature/Http/Controllers/ChannelsControllerTest.php
+++ b/tests/Feature/Http/Controllers/ChannelsControllerTest.php
@@ -13,6 +13,8 @@ use Illuminate\Support\Str;
 use PHPUnit\Framework\Attributes\Medium;
 use Tests\TestCase;
 
+use function sprintf;
+
 #[Medium]
 final class ChannelsControllerTest extends TestCase
 {

--- a/tests/Feature/Http/Controllers/EventsControllerTest.php
+++ b/tests/Feature/Http/Controllers/EventsControllerTest.php
@@ -14,6 +14,8 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Medium;
 use Tests\TestCase;
 
+use function sprintf;
+
 #[Group('events')]
 #[Medium]
 final class EventsControllerTest extends TestCase

--- a/tests/Feature/Http/Controllers/Import/Chummer5ControllerTest.php
+++ b/tests/Feature/Http/Controllers/Import/Chummer5ControllerTest.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Medium;
 use Tests\TestCase;
 
+use function dirname;
+
 use const DIRECTORY_SEPARATOR;
 
 #[Group('chummer5')]

--- a/tests/Feature/Http/Responses/Discord/RegisterResponseTest.php
+++ b/tests/Feature/Http/Responses/Discord/RegisterResponseTest.php
@@ -18,6 +18,9 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Medium;
 use Tests\TestCase;
 
+use function in_array;
+use function sprintf;
+
 #[Group('discord')]
 #[Medium]
 final class RegisterResponseTest extends TestCase
@@ -58,7 +61,7 @@ final class RegisterResponseTest extends TestCase
         $expected = sprintf(
             '"invalid" is not a valid system code. Use `register '
                 . '<system>`, where system is one of: %s',
-            \implode(', ', \array_keys(config('commlink.systems'))),
+            implode(', ', array_keys(config('commlink.systems'))),
         );
         $messageMock = $this->createDiscordMessageMock('/roll register invalid');
         $messageMock->expects(self::once())
@@ -115,7 +118,7 @@ final class RegisterResponseTest extends TestCase
         Event::fake();
         Http::fake();
 
-        $expected = \sprintf(
+        $expected = sprintf(
             'You must have already created an account on %s (%s) and '
                 . 'linked it to this server before you can register a '
                 . 'channel to a specific system.',
@@ -158,7 +161,7 @@ final class RegisterResponseTest extends TestCase
             'server_type' => ChatUser::TYPE_DISCORD,
             'verified' => true,
         ]);
-        $expected = \sprintf(
+        $expected = sprintf(
             '%s has registered this channel for the "Shadowrun 5th Edition" system.',
             // @phpstan-ignore property.notFound
             $event->channel->username,
@@ -210,7 +213,7 @@ final class RegisterResponseTest extends TestCase
             'server_type' => ChatUser::TYPE_DISCORD,
             'verified' => true,
         ]);
-        $expected = \sprintf(
+        $expected = sprintf(
             '%s has registered this channel for the "Shadowrun 5th Edition" system.',
             // @phpstan-ignore property.notFound
             $event->channel->username,

--- a/tests/Feature/Http/Responses/Slack/LinkResponseTest.php
+++ b/tests/Feature/Http/Responses/Slack/LinkResponseTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\Medium;
 use Tests\TestCase;
 
 use function sha1;
+use function sprintf;
 
 #[Group('slack')]
 #[Medium]

--- a/tests/Feature/Listeners/HandleDiscordMessageTest.php
+++ b/tests/Feature/Listeners/HandleDiscordMessageTest.php
@@ -24,6 +24,8 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Medium;
 use Tests\TestCase;
 
+use function sprintf;
+
 use const PHP_EOL;
 
 #[Group('discord')]

--- a/tests/Feature/Models/Traits/InteractsWithDiscordTest.php
+++ b/tests/Feature/Models/Traits/InteractsWithDiscordTest.php
@@ -13,6 +13,8 @@ use PHPUnit\Framework\Attributes\Small;
 use RuntimeException;
 use Tests\TestCase;
 
+use function sprintf;
+
 #[Group('discord')]
 #[Small]
 final class InteractsWithDiscordTest extends TestCase

--- a/tests/Feature/Rolls/RsvpTest.php
+++ b/tests/Feature/Rolls/RsvpTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\Attributes\Medium;
 use Tests\TestCase;
 
 use function json_encode;
+use function sprintf;
 
 #[Group('campaigns')]
 #[Medium]

--- a/tests/Feature/Services/Chummer/Shadowrun5eConverterTest.php
+++ b/tests/Feature/Services/Chummer/Shadowrun5eConverterTest.php
@@ -12,6 +12,8 @@ use PHPUnit\Framework\Attributes\Small;
 use RuntimeException;
 use Tests\TestCase;
 
+use function dirname;
+
 use const DIRECTORY_SEPARATOR;
 
 #[Group('chummer5')]


### PR DESCRIPTION
For namespaced files, functions should be imported. For global files, nothing is needed.

Closes #1802 