### PR TITLE
Laravel Linter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,7 +51,6 @@ DB_PASSWORD=""
 
 # For testing
 DB_CONNECTION=sqlite
-DATABASE_URL=""
 DB_DATABASE="/tmp/commlink-test"
 
 MONGO_HOST=localhost

--- a/.shift
+++ b/.shift
@@ -1,4 +1,0 @@
-This file was added by Shift #140512 in order to open a
-Pull Request since no other commits were made.
-
-You should remove this file.

--- a/.shift
+++ b/.shift
@@ -1,0 +1,4 @@
+This file was added by Shift #140512 in order to open a
+Pull Request since no other commits were made.
+
+You should remove this file.

--- a/config/auth.php
+++ b/config/auth.php
@@ -3,90 +3,115 @@
 declare(strict_types=1);
 
 return [
+
     /*
-     * Authentication Defaults
-     *
-     * This option controls the default authentication "guard" and password
-     * reset options for your application. You may change these defaults as
-     * required, but they're a perfect start for most applications.
-     */
+    |--------------------------------------------------------------------------
+    | Authentication Defaults
+    |--------------------------------------------------------------------------
+    |
+    | This option defines the default authentication "guard" and password
+    | reset "broker" for your application. You may change these values
+    | as required, but they're a perfect start for most applications.
+    |
+    */
+
     'defaults' => [
-        'guard' => 'web',
-        'passwords' => 'users',
+        'guard' => env('AUTH_GUARD', 'web'),
+        'passwords' => env('AUTH_PASSWORD_BROKER', 'users'),
     ],
 
     /*
-     * Authentication Guards
-     *
-     * Next, you may define every authentication guard for your application. Of
-     * course, a great default configuration has been defined for you here which
-     * uses session storage and the Eloquent user provider.
-     *
-     * All authentication drivers have a user provider. This defines how the
-     * users are actually retrieved out of your database or other storage
-     * mechanisms used by this application to persist your user's data.
-     *
-     * Supported: "session", "token"
-     */
+    |--------------------------------------------------------------------------
+    | Authentication Guards
+    |--------------------------------------------------------------------------
+    |
+    | Next, you may define every authentication guard for your application.
+    | Of course, a great default configuration has been defined for you
+    | which utilizes session storage plus the Eloquent user provider.
+    |
+    | All authentication guards have a user provider, which defines how the
+    | users are actually retrieved out of your database or other storage
+    | system used by the application. Typically, Eloquent is utilized.
+    |
+    | Supported: "session"
+    |
+    */
+
     'guards' => [
         'web' => [
             'driver' => 'session',
             'provider' => 'users',
         ],
-
-        'api' => [
-            'driver' => 'token',
-            'provider' => 'users',
-            'hash' => false,
-        ],
     ],
 
     /*
-     * User Providers
-     *
-     * All authentication drivers have a user provider. This defines how the
-     * users are actually retrieved out of your database or other storage
-     * mechanisms used by this application to persist your user's data.
-     *
-     * If you have multiple user tables or models you may configure multiple
-     * sources which represent each model / table. These sources may then be
-     * assigned to any extra authentication guards you have defined.
-     *
-     * Supported: "database", "eloquent"
-     */
+    |--------------------------------------------------------------------------
+    | User Providers
+    |--------------------------------------------------------------------------
+    |
+    | All authentication guards have a user provider, which defines how the
+    | users are actually retrieved out of your database or other storage
+    | system used by the application. Typically, Eloquent is utilized.
+    |
+    | If you have multiple user tables or models you may configure multiple
+    | providers to represent the model / table. These providers may then
+    | be assigned to any extra authentication guards you have defined.
+    |
+    | Supported: "database", "eloquent"
+    |
+    */
+
     'providers' => [
         'users' => [
             'driver' => 'eloquent',
-            'model' => App\Models\User::class,
+            'model' => env('AUTH_MODEL', App\Models\User::class),
         ],
+
+        // 'users' => [
+        //     'driver' => 'database',
+        //     'table' => 'users',
+        // ],
     ],
 
     /*
-     * Resetting Passwords
-     *
-     * You may specify multiple password reset configurations if you have more
-     * than one user table or model in the application and you want to have
-     * separate password reset settings based on the specific user types.
-     *
-     * The expire time is the number of minutes that the reset token should be
-     * considered valid. This security feature keeps tokens short-lived so they
-     * have less time to be guessed. You may change this as needed.
-     */
+    |--------------------------------------------------------------------------
+    | Resetting Passwords
+    |--------------------------------------------------------------------------
+    |
+    | These configuration options specify the behavior of Laravel's password
+    | reset functionality, including the table utilized for token storage
+    | and the user provider that is invoked to actually retrieve users.
+    |
+    | The expiry time is the number of minutes that each reset token will be
+    | considered valid. This security feature keeps tokens short-lived so
+    | they have less time to be guessed. You may change this as needed.
+    |
+    | The throttle setting is the number of seconds a user must wait before
+    | generating more password reset tokens. This prevents the user from
+    | quickly generating a very large amount of password reset tokens.
+    |
+    */
+
     'passwords' => [
         'users' => [
             'provider' => 'users',
-            'table' => 'password_resets',
+            'table' => env('AUTH_PASSWORD_RESET_TOKEN_TABLE', 'password_reset_tokens'),
             'expire' => 60,
             'throttle' => 60,
         ],
     ],
 
     /*
-     * Password Confirmation Timeout
-     *
-     * Here you may define the amount of seconds before a password confirmation
-     * times out and the user is prompted to re-enter their password via the
-     * confirmation screen. By default, the timeout lasts for three hours.
+    |--------------------------------------------------------------------------
+    | Password Confirmation Timeout
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define the amount of seconds before a password confirmation
+    | window expires and users are asked to re-enter their password via the
+    | confirmation screen. By default, the timeout lasts for three hours.
+    |
     */
-    'password_timeout' => 10800,
+
+    'password_timeout' => env('AUTH_PASSWORD_TIMEOUT', 10800),
+
 ];

--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -3,27 +3,51 @@
 declare(strict_types=1);
 
 return [
-    /*
-     * Default Broadcaster
-     *
-     * This option controls the default broadcaster that will be used by the
-     * framework when an event needs to be broadcast. You may set this to any of
-     * the connections defined in the "connections" array below.
-     *
-     * Supported: "pusher", "redis", "log", "null"
-     */
-    'default' => env('BROADCAST_DRIVER', 'null'),
 
     /*
-     *--------------------------------------------------------------------------
-     * Broadcast Connections
-     *--------------------------------------------------------------------------
-     *
-     * Here you may define all of the broadcast connections that will be used to
-     * broadcast events to other systems or over websockets. Samples of each
-     * available type of connection are provided inside this array.
-     */
+    |--------------------------------------------------------------------------
+    | Default Broadcaster
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default broadcaster that will be used by the
+    | framework when an event needs to be broadcast. You may set this to
+    | any of the connections defined in the "connections" array below.
+    |
+    | Supported: "reverb", "pusher", "ably", "redis", "log", "null"
+    |
+    */
+
+    'default' => env('BROADCAST_CONNECTION', 'null'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Broadcast Connections
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define all of the broadcast connections that will be used
+    | to broadcast events to other systems or over WebSockets. Samples of
+    | each available type of connection are provided inside this array.
+    |
+    */
+
     'connections' => [
+
+        'reverb' => [
+            'driver' => 'reverb',
+            'key' => env('REVERB_APP_KEY'),
+            'secret' => env('REVERB_APP_SECRET'),
+            'app_id' => env('REVERB_APP_ID'),
+            'options' => [
+                'host' => env('REVERB_HOST'),
+                'port' => env('REVERB_PORT', 443),
+                'scheme' => env('REVERB_SCHEME', 'https'),
+                'useTLS' => 'https' === env('REVERB_SCHEME', 'https'),
+            ],
+            'client_options' => [
+                // Guzzle client options: https://docs.guzzlephp.org/en/stable/request-options.html
+            ],
+        ],
+
         'pusher' => [
             'driver' => 'pusher',
             'key' => env('PUSHER_APP_KEY'),
@@ -31,18 +55,20 @@ return [
             'app_id' => env('PUSHER_APP_ID'),
             'options' => [
                 'cluster' => env('PUSHER_APP_CLUSTER'),
-                'useTLS' => true,
+                'host' => env('PUSHER_HOST') ?: 'api-' . env('PUSHER_APP_CLUSTER', 'mt1') . '.pusher.com',
+                'port' => env('PUSHER_PORT', 443),
+                'scheme' => env('PUSHER_SCHEME', 'https'),
+                'encrypted' => true,
+                'useTLS' => 'https' === env('PUSHER_SCHEME', 'https'),
+            ],
+            'client_options' => [
+                // Guzzle client options: https://docs.guzzlephp.org/en/stable/request-options.html
             ],
         ],
 
         'ably' => [
             'driver' => 'ably',
             'key' => env('ABLY_KEY'),
-        ],
-
-        'redis' => [
-            'driver' => 'redis',
-            'connection' => 'default',
         ],
 
         'log' => [
@@ -52,5 +78,7 @@ return [
         'null' => [
             'driver' => 'null',
         ],
+
     ],
+
 ];

--- a/config/cache.php
+++ b/config/cache.php
@@ -5,43 +5,55 @@ declare(strict_types=1);
 use Illuminate\Support\Str;
 
 return [
-    /*
-     * Default Cache Store
-     *
-     * This option controls the default cache connection that gets used while
-     * using this caching library. This connection is used when another is not
-     * explicitly specified when executing a given caching function.
-     */
-    'default' => env('CACHE_DRIVER', 'file'),
 
     /*
-     * Cache Stores
-     *
-     * Here you may define all of the cache "stores" for your application as
-     * well as their drivers. You may even define multiple stores for the same
-     * cache driver to group types of items stored in your caches.
-     *
-     * Supported drivers: "apc", "array", "database", "file", "memcached",
-     * "redis", "dynamodb", "null"
-     */
+    |--------------------------------------------------------------------------
+    | Default Cache Store
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default cache store that will be used by the
+    | framework. This connection is utilized if another isn't explicitly
+    | specified when running a cache operation inside the application.
+    |
+    */
+
+    'default' => env('CACHE_STORE', 'database'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cache Stores
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define all of the cache "stores" for your application as
+    | well as their drivers. You may even define multiple stores for the
+    | same cache driver to group types of items stored in your caches.
+    |
+    | Supported drivers: "array", "database", "file", "memcached",
+    |                    "redis", "dynamodb", "octane", "null"
+    |
+    */
+
     'stores' => [
-        'apc' => [
-            'driver' => 'apc',
-        ],
+
         'array' => [
             'driver' => 'array',
             'serialize' => false,
         ],
+
         'database' => [
             'driver' => 'database',
-            'table' => 'cache',
-            'connection' => null,
-            'lock_connection' => null,
+            'connection' => env('DB_CACHE_CONNECTION'),
+            'table' => env('DB_CACHE_TABLE', 'cache'),
+            'lock_connection' => env('DB_CACHE_LOCK_CONNECTION'),
+            'lock_table' => env('DB_CACHE_LOCK_TABLE'),
         ],
+
         'file' => [
             'driver' => 'file',
             'path' => storage_path('framework/cache/data'),
+            'lock_path' => storage_path('framework/cache/data'),
         ],
+
         'memcached' => [
             'driver' => 'memcached',
             'persistent_id' => env('MEMCACHED_PERSISTENT_ID'),
@@ -50,6 +62,7 @@ return [
                 env('MEMCACHED_PASSWORD'),
             ],
             'options' => [
+                // Memcached::OPT_CONNECT_TIMEOUT => 2000,
             ],
             'servers' => [
                 [
@@ -59,11 +72,13 @@ return [
                 ],
             ],
         ],
+
         'redis' => [
             'driver' => 'redis',
-            'connection' => 'cache',
-            'lock_connection' => 'default',
+            'connection' => env('REDIS_CACHE_CONNECTION', 'cache'),
+            'lock_connection' => env('REDIS_CACHE_LOCK_CONNECTION', 'default'),
         ],
+
         'dynamodb' => [
             'driver' => 'dynamodb',
             'key' => env('AWS_ACCESS_KEY_ID'),
@@ -72,15 +87,24 @@ return [
             'table' => env('DYNAMODB_CACHE_TABLE', 'cache'),
             'endpoint' => env('DYNAMODB_ENDPOINT'),
         ],
+
+        'octane' => [
+            'driver' => 'octane',
+        ],
+
     ],
 
     /*
-     * Cache Key Prefix
-     *
-     * When utilizing a RAM based store such as APC or Memcached, there might be
-     * other applications utilizing the same cache. So, we'll specify a value to
-     * get prefixed to all our keys so we can avoid collisions.
-     */
-    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_')
-        . '_cache'),
+    |--------------------------------------------------------------------------
+    | Cache Key Prefix
+    |--------------------------------------------------------------------------
+    |
+    | When utilizing the APC, database, memcached, Redis, and DynamoDB cache
+    | stores, there might be other applications using the same cache. For
+    | that reason, you may prefix every cache key to avoid collisions.
+    |
+    */
+
+    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_') . '_cache_'),
+
 ];

--- a/config/database.php
+++ b/config/database.php
@@ -5,38 +5,56 @@ declare(strict_types=1);
 use Illuminate\Support\Str;
 
 return [
-    /*
-     * Default Database Connection Name
-     *
-     * Here you may specify which of the database connections below you wish to
-     * use as your default connection for all database work. Of course you may
-     * use many connections at once using the Database library.
-    */
-    'default' => env('DB_CONNECTION', 'mysql'),
 
     /*
-     * Database Connections
-     *
-     * Here are each of the database connections setup for your application. Of
-     * course, examples of configuring each database platform that is supported
-     * by Laravel is shown below to make development simple.
-     *
-     * All database work in Laravel is done through the PHP PDO facilities so
-     * make sure you have the driver for your particular database of choice
-     * installed on your machine before you begin development.
+    |--------------------------------------------------------------------------
+    | Default Database Connection Name
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify which of the database connections below you wish
+    | to use as your default connection for database operations. This is
+    | the connection which will be utilized unless another connection
+    | is explicitly specified when you execute a query / statement.
+    |
     */
+
+    'default' => env('DB_CONNECTION', 'sqlite'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Database Connections
+    |--------------------------------------------------------------------------
+    |
+    | Below are all of the database connections defined for your application.
+    | An example configuration is provided for each database system which
+    | is supported by Laravel. You're free to add / remove connections.
+    |
+    */
+
     'connections' => [
+
+        'sqlite' => [
+            'driver' => 'sqlite',
+            'url' => env('DB_URL'),
+            'database' => env('DB_DATABASE', database_path('database.sqlite')),
+            'prefix' => '',
+            'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
+            'busy_timeout' => null,
+            'journal_mode' => null,
+            'synchronous' => null,
+        ],
+
         'mysql' => [
             'driver' => 'mysql',
-            'url' => env('DATABASE_URL'),
+            'url' => env('DB_URL'),
             'host' => env('DB_HOST', '127.0.0.1'),
             'port' => env('DB_PORT', '3306'),
-            'database' => env('DB_DATABASE', 'forge'),
-            'username' => env('DB_USERNAME', 'forge'),
+            'database' => env('DB_DATABASE', 'laravel'),
+            'username' => env('DB_USERNAME', 'root'),
             'password' => env('DB_PASSWORD', ''),
             'unix_socket' => env('DB_SOCKET', ''),
-            'charset' => 'utf8mb4',
-            'collation' => 'utf8mb4_unicode_ci',
+            'charset' => env('DB_CHARSET', 'utf8mb4'),
+            'collation' => env('DB_COLLATION', 'utf8mb4_unicode_ci'),
             'prefix' => '',
             'prefix_indexes' => true,
             'strict' => true,
@@ -45,17 +63,18 @@ return [
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
-        'mysql-test' => [
-            'driver' => 'mysql',
-            'url' => env('DATABASE_URL'),
+
+        'mariadb' => [
+            'driver' => 'mariadb',
+            'url' => env('DB_URL'),
             'host' => env('DB_HOST', '127.0.0.1'),
             'port' => env('DB_PORT', '3306'),
-            'database' => env('DB_DATABASE', 'forge') . '-test',
-            'username' => env('DB_USERNAME', 'forge') . '-test',
+            'database' => env('DB_DATABASE', 'laravel'),
+            'username' => env('DB_USERNAME', 'root'),
             'password' => env('DB_PASSWORD', ''),
             'unix_socket' => env('DB_SOCKET', ''),
-            'charset' => 'utf8mb4',
-            'collation' => 'utf8mb4_unicode_ci',
+            'charset' => env('DB_CHARSET', 'utf8mb4'),
+            'collation' => env('DB_COLLATION', 'utf8mb4_unicode_ci'),
             'prefix' => '',
             'prefix_indexes' => true,
             'strict' => true,
@@ -64,6 +83,7 @@ return [
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
+
         'mongodb' => [
             'driver' => 'mongodb',
             'host' => env('MONGO_HOST', '127.0.0.1'),
@@ -75,64 +95,94 @@ return [
                 'database' => env('MONGO_AUTHENTICATION_DATABASE', 'admin'),
             ],
         ],
-        'mongodb-test' => [
-            'driver' => 'mongodb',
-            'host' => env('MONGO_HOST', '127.0.0.1'),
-            'port' => env('MONGO_PORT', 27017),
-            'database' => env('MONGO_DATABASE', 'homestead'),
-            'username' => env('MONGO_USERNAME', 'homestead'),
-            'password' => env('MONGO_PASSWORD', 'secret'),
-            'options' => [
-                'database' => env('MONGO_AUTHENTICATION_DATABASE', 'admin'),
-            ],
-        ],
-        'sqlite' => [
-            'driver' => 'sqlite',
-            'url' => env('DATABASE_URL'),
-            'database' => env('DB_DATABASE', database_path('database.sqlite')),
+
+        'pgsql' => [
+            'driver' => 'pgsql',
+            'url' => env('DB_URL'),
+            'host' => env('DB_HOST', '127.0.0.1'),
+            'port' => env('DB_PORT', '5432'),
+            'database' => env('DB_DATABASE', 'laravel'),
+            'username' => env('DB_USERNAME', 'root'),
+            'password' => env('DB_PASSWORD', ''),
+            'charset' => env('DB_CHARSET', 'utf8'),
             'prefix' => '',
-            'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
+            'prefix_indexes' => true,
+            'search_path' => 'public',
+            'sslmode' => 'prefer',
         ],
+
+        'sqlsrv' => [
+            'driver' => 'sqlsrv',
+            'url' => env('DB_URL'),
+            'host' => env('DB_HOST', 'localhost'),
+            'port' => env('DB_PORT', '1433'),
+            'database' => env('DB_DATABASE', 'laravel'),
+            'username' => env('DB_USERNAME', 'root'),
+            'password' => env('DB_PASSWORD', ''),
+            'charset' => env('DB_CHARSET', 'utf8'),
+            'prefix' => '',
+            'prefix_indexes' => true,
+            // 'encrypt' => env('DB_ENCRYPT', 'yes'),
+            // 'trust_server_certificate' => env('DB_TRUST_SERVER_CERTIFICATE', 'false'),
+        ],
+
     ],
 
     /*
-     * Migration Repository Table
-     *
-     * This table keeps track of all the migrations that have already run for
-     * your application. Using this information, we can determine which of the
-     * migrations on disk haven't actually been run in the database.
+    |--------------------------------------------------------------------------
+    | Migration Repository Table
+    |--------------------------------------------------------------------------
+    |
+    | This table keeps track of all the migrations that have already run for
+    | your application. Using this information, we can determine which of
+    | the migrations on disk haven't actually been run on the database.
+    |
     */
-    'migrations' => 'migrations',
+
+    'migrations' => [
+        'table' => 'migrations',
+        'update_date_on_publish' => true,
+    ],
 
     /*
-     * Redis Databases
-     *
-     * Redis is an open source, fast, and advanced key-value store that also
-     * provides a richer body of commands than a typical key-value system such
-     * as APC or Memcached. Laravel makes it easy to dig right in.
+    |--------------------------------------------------------------------------
+    | Redis Databases
+    |--------------------------------------------------------------------------
+    |
+    | Redis is an open source, fast, and advanced key-value store that also
+    | provides a richer body of commands than a typical key-value system
+    | such as Memcached. You may define your connection settings here.
+    |
     */
+
     'redis' => [
+
         'client' => env('REDIS_CLIENT', 'phpredis'),
+
         'options' => [
             'cluster' => env('REDIS_CLUSTER', 'redis'),
-            'prefix' => env(
-                'REDIS_PREFIX',
-                Str::slug(env('APP_NAME', 'laravel'), '_') . '_database_'
-            ),
+            'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_') . '_database_'),
+            'persistent' => env('REDIS_PERSISTENT', false),
         ],
+
         'default' => [
             'url' => env('REDIS_URL'),
             'host' => env('REDIS_HOST', '127.0.0.1'),
-            'password' => env('REDIS_PASSWORD', null),
+            'username' => env('REDIS_USERNAME'),
+            'password' => env('REDIS_PASSWORD'),
             'port' => env('REDIS_PORT', '6379'),
             'database' => env('REDIS_DB', '0'),
         ],
+
         'cache' => [
             'url' => env('REDIS_URL'),
             'host' => env('REDIS_HOST', '127.0.0.1'),
-            'password' => env('REDIS_PASSWORD', null),
+            'username' => env('REDIS_USERNAME'),
+            'password' => env('REDIS_PASSWORD'),
             'port' => env('REDIS_PORT', '6379'),
             'database' => env('REDIS_CACHE_DB', '1'),
         ],
+
     ],
+
 ];

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -3,45 +3,79 @@
 declare(strict_types=1);
 
 return [
-    /*
-     * Default Filesystem Disk
-     *
-     * Here you may specify the default filesystem disk that should be used by
-     * the framework. The "local" disk, as well as a variety of cloud based
-     * disks are available to your application. Just store away!
-     */
-    'default' => env('FILESYSTEM_DRIVER', 'local'),
 
     /*
-     * Filesystem Disks
-     *
-     * Here you may configure as many filesystem "disks" as you wish, and you
-     * may even configure multiple disks of the same driver. Defaults have been
-     * setup for each driver as an example of the required options.
-     *
-     * Supported Drivers: "local", "ftp", "sftp", "s3"
-     */
+    |--------------------------------------------------------------------------
+    | Default Filesystem Disk
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the default filesystem disk that should be used
+    | by the framework. The "local" disk, as well as a variety of cloud
+    | based disks are available to your application for file storage.
+    |
+    */
+
+    'default' => env('FILESYSTEM_DISK', 'local'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Filesystem Disks
+    |--------------------------------------------------------------------------
+    |
+    | Below you may configure as many filesystem disks as necessary, and you
+    | may even configure multiple disks for the same driver. Examples for
+    | most supported storage drivers are configured here for reference.
+    |
+    | Supported drivers: "local", "ftp", "sftp", "s3"
+    |
+    */
+
     'disks' => [
+
         'local' => [
             'driver' => 'local',
             'root' => storage_path('app'),
+            'throw' => false,
+            'report' => false,
         ],
+
         'public' => [
             'driver' => 'local',
             'root' => storage_path('app/public'),
             'url' => env('APP_URL') . '/storage',
             'visibility' => 'public',
+            'throw' => false,
+            'report' => false,
         ],
+
+        's3' => [
+            'driver' => 's3',
+            'key' => env('AWS_ACCESS_KEY_ID'),
+            'secret' => env('AWS_SECRET_ACCESS_KEY'),
+            'region' => env('AWS_DEFAULT_REGION'),
+            'bucket' => env('AWS_BUCKET'),
+            'url' => env('AWS_URL'),
+            'endpoint' => env('AWS_ENDPOINT'),
+            'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
+            'throw' => false,
+            'report' => false,
+        ],
+
     ],
 
     /*
-     * Symbolic Links
-     *
-     * Here you may configure the symbolic links that will be created when the
-     * `storage:link` Artisan command is executed. The array keys should be the
-     * locations of the links and the values should be their targets.
-     */
+    |--------------------------------------------------------------------------
+    | Symbolic Links
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the symbolic links that will be created when the
+    | `storage:link` Artisan command is executed. The array keys should be
+    | the locations of the links and the values should be their targets.
+    |
+    */
+
     'links' => [
         public_path('storage') => storage_path('app/public'),
     ],
+
 ];

--- a/config/hashing.php
+++ b/config/hashing.php
@@ -3,25 +3,67 @@
 declare(strict_types=1);
 
 return [
-    /*
-     * Default Hash Driver
-     *
-     * This option controls the default hash driver that will be used to hash
-     * passwords for your application. By default, the bcrypt algorithm is used;
-     * however, you remain free to modify this option if you wish.
-     *
-     * Supported: "bcrypt", "argon", "argon2id"
-     */
-    'driver' => 'bcrypt',
 
     /*
-     * Bcrypt Options
-     *
-     * Here you may specify the configuration options that should be used when
-     * passwords are hashed using the Bcrypt algorithm. This will allow you to
-     * control the amount of time it takes to hash the given password.
-     */
+    |--------------------------------------------------------------------------
+    | Default Hash Driver
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default hash driver that will be used to hash
+    | passwords for your application. By default, the bcrypt algorithm is
+    | used; however, you remain free to modify this option if you wish.
+    |
+    | Supported: "bcrypt", "argon", "argon2id"
+    |
+    */
+
+    'driver' => env('HASH_DRIVER', 'bcrypt'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Bcrypt Options
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the configuration options that should be used when
+    | passwords are hashed using the Bcrypt algorithm. This will allow you
+    | to control the amount of time it takes to hash the given password.
+    |
+    */
+
     'bcrypt' => [
-        'rounds' => env('BCRYPT_ROUNDS', 10),
+        'rounds' => env('BCRYPT_ROUNDS', 12),
+        'verify' => env('HASH_VERIFY', true),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Argon Options
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the configuration options that should be used when
+    | passwords are hashed using the Argon algorithm. These will allow you
+    | to control the amount of time it takes to hash the given password.
+    |
+    */
+
+    'argon' => [
+        'memory' => env('ARGON_MEMORY', 65536),
+        'threads' => env('ARGON_THREADS', 1),
+        'time' => env('ARGON_TIME', 4),
+        'verify' => env('HASH_VERIFY', true),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Rehash On Login
+    |--------------------------------------------------------------------------
+    |
+    | Setting this option to true will tell Laravel to automatically rehash
+    | the user's password during login if the configured work factor for
+    | the algorithm has changed, allowing graceful upgrades of hashes.
+    |
+    */
+
+    'rehash_on_login' => true,
+
 ];

--- a/config/logging.php
+++ b/config/logging.php
@@ -5,87 +5,130 @@ declare(strict_types=1);
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
+use Monolog\Processor\PsrLogMessageProcessor;
 
 return [
-    /*
-     * Default Log Channel
-     *
-     * This option defines the default log channel that gets used when writing
-     * messages to the logs. The name specified in this option should match one
-     * of the channels defined in the "channels" configuration array.
-     */
-    'default' => env('LOG_CHANNEL', 'stack'),
-    'deprecations' => env('LOG_DEPRECATIONS_CHANNEL', 'null'),
 
     /*
-     * Log Channels
-     *
-     * Here you may configure the log channels for your application. Out of the
-     * box, Laravel uses the Monolog PHP logging library. This gives you a
-     * variety of powerful log handlers / formatters to utilize.
-     *
-     * Available Drivers: "single", "daily", "slack", "syslog", "errorlog",
-     * "monolog", "custom", "stack"
-     */
+    |--------------------------------------------------------------------------
+    | Default Log Channel
+    |--------------------------------------------------------------------------
+    |
+    | This option defines the default log channel that is utilized to write
+    | messages to your logs. The value provided here should match one of
+    | the channels present in the list of "channels" configured below.
+    |
+    */
+
+    'default' => env('LOG_CHANNEL', 'stack'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Deprecations Log Channel
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the log channel that should be used to log warnings
+    | regarding deprecated PHP and library features. This allows you to get
+    | your application ready for upcoming major versions of dependencies.
+    |
+    */
+
+    'deprecations' => [
+        'channel' => env('LOG_DEPRECATIONS_CHANNEL', 'null'),
+        'trace' => env('LOG_DEPRECATIONS_TRACE', false),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Log Channels
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the log channels for your application. Laravel
+    | utilizes the Monolog PHP logging library, which includes a variety
+    | of powerful log handlers and formatters that you're free to use.
+    |
+    | Available drivers: "single", "daily", "slack", "syslog",
+    |                    "errorlog", "monolog", "custom", "stack"
+    |
+    */
+
     'channels' => [
-        'daily' => [
-            'driver' => 'daily',
-            'path' => storage_path('logs/laravel.log'),
-            'level' => env('LOG_LEVEL', 'debug'),
-            'days' => 14,
+
+        'stack' => [
+            'driver' => 'stack',
+            'channels' => explode(',', env('LOG_STACK', 'single')),
+            'ignore_exceptions' => false,
         ],
-        'deprecations' => [
-            'driver' => 'single',
-            'path' => storage_path('logs/deprecation-warnings.log'),
-        ],
-        'emergency' => [
-            'path' => storage_path('logs/laravel.log'),
-        ],
-        'errorlog' => [
-            'driver' => 'errorlog',
-            'level' => env('LOG_LEVEL', 'debug'),
-        ],
-        'null' => [
-            'driver' => 'monolog',
-            'handler' => NullHandler::class,
-        ],
+
         'single' => [
             'driver' => 'single',
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'debug'),
+            'replace_placeholders' => true,
         ],
+
+        'daily' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/laravel.log'),
+            'level' => env('LOG_LEVEL', 'debug'),
+            'days' => env('LOG_DAILY_DAYS', 14),
+            'replace_placeholders' => true,
+        ],
+
         'slack' => [
             'driver' => 'slack',
             'url' => env('LOG_SLACK_WEBHOOK_URL'),
-            'username' => 'Laravel Log',
-            'emoji' => ':boom:',
+            'username' => env('LOG_SLACK_USERNAME', 'Laravel Log'),
+            'emoji' => env('LOG_SLACK_EMOJI', ':boom:'),
             'level' => env('LOG_LEVEL', 'critical'),
+            'replace_placeholders' => true,
         ],
-        'stack' => [
-            'driver' => 'stack',
-            'channels' => ['single'],
-            'ignore_exceptions' => false,
-        ],
+
         'papertrail' => [
             'driver' => 'monolog',
             'level' => env('LOG_LEVEL', 'debug'),
-            'handler' => SyslogUdpHandler::class,
+            'handler' => env('LOG_PAPERTRAIL_HANDLER', SyslogUdpHandler::class),
             'handler_with' => [
                 'host' => env('PAPERTRAIL_URL'),
                 'port' => env('PAPERTRAIL_PORT'),
+                'connectionString' => 'tls://' . env('PAPERTRAIL_URL') . ':' . env('PAPERTRAIL_PORT'),
             ],
+            'processors' => [PsrLogMessageProcessor::class],
         ],
+
         'stderr' => [
             'driver' => 'monolog',
+            'level' => env('LOG_LEVEL', 'debug'),
             'handler' => StreamHandler::class,
             'formatter' => env('LOG_STDERR_FORMATTER'),
             'with' => [
                 'stream' => 'php://stderr',
             ],
+            'processors' => [PsrLogMessageProcessor::class],
         ],
+
         'syslog' => [
             'driver' => 'syslog',
             'level' => env('LOG_LEVEL', 'debug'),
+            'facility' => env('LOG_SYSLOG_FACILITY', \LOG_USER),
+            'replace_placeholders' => true,
         ],
+
+        'errorlog' => [
+            'driver' => 'errorlog',
+            'level' => env('LOG_LEVEL', 'debug'),
+            'replace_placeholders' => true,
+        ],
+
+        'null' => [
+            'driver' => 'monolog',
+            'handler' => NullHandler::class,
+        ],
+
+        'emergency' => [
+            'path' => storage_path('logs/laravel.log'),
+        ],
+
     ],
+
 ];

--- a/config/mail.php
+++ b/config/mail.php
@@ -3,85 +3,135 @@
 declare(strict_types=1);
 
 return [
-    /*
-     * Default Mailer
-     *
-     * This option controls the default mailer that is used to send any email
-     * messages sent by your application. Alternative mailers may be setup and
-     * used as needed; however, this mailer will be used by default.
-     */
-    'default' => env('MAIL_MAILER', 'smtp'),
 
     /*
-     * Mailer Configurations
-     *
-     * Here you may configure all of the mailers used by your application plus
-     * their respective settings. Several examples have been configured for you
-     * and you are free to add your own as your application requires.
-     *
-     * Laravel supports a variety of mail "transport" drivers to be used while
-     * sending an e-mail. You will specify which one you are using for your
-     * mailers below. You are free to add additional mailers as required.
-     *
-     * Supported: "smtp", "sendmail", "mailgun", "ses", "ses-v2", "postmark",
-     * "log", "array"
-     */
+    |--------------------------------------------------------------------------
+    | Default Mailer
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default mailer that is used to send all email
+    | messages unless another mailer is explicitly specified when sending
+    | the message. All additional mailers can be configured within the
+    | "mailers" array. Examples of each type of mailer are provided.
+    |
+    */
+
+    'default' => env('MAIL_MAILER', 'log'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Mailer Configurations
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure all of the mailers used by your application plus
+    | their respective settings. Several examples have been configured for
+    | you and you are free to add your own as your application requires.
+    |
+    | Laravel supports a variety of mail "transport" drivers that can be used
+    | when delivering an email. You may specify which one you're using for
+    | your mailers below. You may also add additional mailers if needed.
+    |
+    | Supported: "smtp", "sendmail", "mailgun", "ses", "ses-v2",
+    |            "postmark", "resend", "log", "array",
+    |            "failover", "roundrobin"
+    |
+    */
+
     'mailers' => [
+
         'smtp' => [
             'transport' => 'smtp',
-            'host' => env('MAIL_HOST', 'smtp.mailgun.org'),
-            'port' => env('MAIL_PORT', 587),
-            'encryption' => env('MAIL_ENCRYPTION', 'tls'),
+            'scheme' => env('MAIL_SCHEME'),
+            'url' => env('MAIL_URL'),
+            'host' => env('MAIL_HOST', '127.0.0.1'),
+            'port' => env('MAIL_PORT', 2525),
             'username' => env('MAIL_USERNAME'),
             'password' => env('MAIL_PASSWORD'),
             'timeout' => null,
-            'auth_mode' => null,
+            'local_domain' => env('MAIL_EHLO_DOMAIN', parse_url(env('APP_URL', 'http://localhost'), \PHP_URL_HOST)),
         ],
+
         'ses' => [
             'transport' => 'ses',
         ],
-        'mailgun' => [
-            'transport' => 'mailgun',
-        ],
+
         'postmark' => [
             'transport' => 'postmark',
+            // 'message_stream_id' => env('POSTMARK_MESSAGE_STREAM_ID'),
+            // 'client' => [
+            //     'timeout' => 5,
+            // ],
         ],
+
+        'resend' => [
+            'transport' => 'resend',
+        ],
+
         'sendmail' => [
             'transport' => 'sendmail',
-            'path' => '/usr/sbin/sendmail -bs',
+            'path' => env('MAIL_SENDMAIL_PATH', '/usr/sbin/sendmail -bs -i'),
         ],
+
         'log' => [
             'transport' => 'log',
             'channel' => env('MAIL_LOG_CHANNEL'),
         ],
+
         'array' => [
             'transport' => 'array',
         ],
+
+        'failover' => [
+            'transport' => 'failover',
+            'mailers' => [
+                'smtp',
+                'log',
+            ],
+        ],
+
+        'roundrobin' => [
+            'transport' => 'roundrobin',
+            'mailers' => [
+                'ses',
+                'postmark',
+            ],
+        ],
+
     ],
 
     /*
-     * Global "From" Address
-     *
-     * You may wish for all e-mails sent by your application to be sent from the
-     * same address. Here, you may specify a name and address that is used
-     * globally for all e-mails that are sent by your application.
-     */
+    |--------------------------------------------------------------------------
+    | Global "From" Address
+    |--------------------------------------------------------------------------
+    |
+    | You may wish for all emails sent by your application to be sent from
+    | the same address. Here you may specify a name and address that is
+    | used globally for all emails that are sent by your application.
+    |
+    */
+
     'from' => [
         'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
         'name' => env('MAIL_FROM_NAME', 'Example'),
     ],
 
     /*
-     * Markdown Mail Settings
-     *
-     * If you are using Markdown based email rendering, you may configure your
-     * theme and component paths here, allowing you to customize the design of
-     * the emails. Or, you may simply stick with the Laravel defaults!
-     */
+    |--------------------------------------------------------------------------
+    | Markdown Mail Settings
+    |--------------------------------------------------------------------------
+    |
+    | If you are using Markdown based email rendering, you may configure your
+    | theme and component paths here, allowing you to customize the design
+    | of the emails. Or, you may simply stick with the Laravel defaults!
+    |
+    */
+
     'markdown' => [
-        'theme' => 'default',
+        'theme' => env('MAIL_MARKDOWN_THEME', 'default'),
+
         'paths' => [
             resource_path('views/vendor/mail'),
         ],
     ],
+
 ];

--- a/config/queue.php
+++ b/config/queue.php
@@ -3,60 +3,112 @@
 declare(strict_types=1);
 
 return [
-    /*
-     * Default Queue Connection Name
-     *
-     * Laravel's queue API supports an assortment of back-ends via a single API,
-     * giving you convenient access to each back-end using the same syntax for
-     * every one. Here you may define a default connection.
-     */
-    'default' => env('QUEUE_CONNECTION', 'sync'),
 
     /*
-     * Queue Connections
-     *
-     * Here you may configure the connection information for each server that is
-     * used by your application. A default configuration has been added for each
-     * back-end shipped with Laravel. You are free to add more.
-     *
-     * Drivers: "sync", "database", "beanstalkd", "sqs", "redis", "null"
-     */
+    |--------------------------------------------------------------------------
+    | Default Queue Connection Name
+    |--------------------------------------------------------------------------
+    |
+    | Laravel's queue supports a variety of backends via a single, unified
+    | API, giving you convenient access to each backend using identical
+    | syntax for each. The default queue connection is defined below.
+    |
+    */
+
+    'default' => env('QUEUE_CONNECTION', 'database'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Queue Connections
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the connection options for every queue backend
+    | used by your application. An example configuration is provided for
+    | each backend supported by Laravel. You're also free to add more.
+    |
+    | Drivers: "sync", "database", "beanstalkd", "sqs", "redis", "null"
+    |
+    */
+
     'connections' => [
+
         'sync' => [
             'driver' => 'sync',
         ],
+
         'database' => [
             'driver' => 'database',
-            'table' => 'jobs',
-            'queue' => 'default',
-            'retry_after' => 90,
+            'connection' => env('DB_QUEUE_CONNECTION'),
+            'table' => env('DB_QUEUE_TABLE', 'jobs'),
+            'queue' => env('DB_QUEUE', 'default'),
+            'retry_after' => (int) env('DB_QUEUE_RETRY_AFTER', 90),
+            'after_commit' => false,
         ],
+
         'beanstalkd' => [
             'driver' => 'beanstalkd',
-            'host' => 'localhost',
-            'queue' => 'default',
-            'retry_after' => 90,
+            'host' => env('BEANSTALKD_QUEUE_HOST', 'localhost'),
+            'queue' => env('BEANSTALKD_QUEUE', 'default'),
+            'retry_after' => (int) env('BEANSTALKD_QUEUE_RETRY_AFTER', 90),
             'block_for' => 0,
+            'after_commit' => false,
         ],
+
+        'sqs' => [
+            'driver' => 'sqs',
+            'key' => env('AWS_ACCESS_KEY_ID'),
+            'secret' => env('AWS_SECRET_ACCESS_KEY'),
+            'prefix' => env('SQS_PREFIX', 'https://sqs.us-east-1.amazonaws.com/your-account-id'),
+            'queue' => env('SQS_QUEUE', 'default'),
+            'suffix' => env('SQS_SUFFIX'),
+            'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
+            'after_commit' => false,
+        ],
+
         'redis' => [
             'driver' => 'redis',
-            'connection' => 'default',
+            'connection' => env('REDIS_QUEUE_CONNECTION', 'default'),
             'queue' => env('REDIS_QUEUE', 'default'),
-            'retry_after' => 90,
+            'retry_after' => (int) env('REDIS_QUEUE_RETRY_AFTER', 90),
             'block_for' => null,
+            'after_commit' => false,
         ],
+
     ],
 
     /*
-     * Failed Queue Jobs
-     *
-     * These options configure the behavior of failed queue job logging so you
-     * can control which database and table are used to store the jobs that have
-     * failed. You may change them to any database / table you wish.
-     */
+    |--------------------------------------------------------------------------
+    | Job Batching
+    |--------------------------------------------------------------------------
+    |
+    | The following options configure the database and table that store job
+    | batching information. These options can be updated to any database
+    | connection and table which has been defined by your application.
+    |
+    */
+
+    'batching' => [
+        'database' => env('DB_CONNECTION', 'sqlite'),
+        'table' => 'job_batches',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Failed Queue Jobs
+    |--------------------------------------------------------------------------
+    |
+    | These options configure the behavior of failed queue job logging so you
+    | can control how and where failed jobs are stored. Laravel ships with
+    | support for storing failed jobs in a simple file or in a database.
+    |
+    | Supported drivers: "database-uuids", "dynamodb", "file", "null"
+    |
+    */
+
     'failed' => [
         'driver' => env('QUEUE_FAILED_DRIVER', 'database-uuids'),
-        'database' => env('DB_CONNECTION', 'mysql'),
+        'database' => env('DB_CONNECTION', 'sqlite'),
         'table' => 'failed_jobs',
     ],
+
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -3,31 +3,38 @@
 declare(strict_types=1);
 
 return [
+
     /*
-     * Third Party Services
-     *
-     * This file is for storing the credentials for third party services such as
-     * Mailgun, Postmark, AWS and more. This file provides the de facto location
-     * for this type of information, allowing packages to have a conventional
-     * file to locate the various service credentials.
-     */
-    'discord' => [
-        'avatar_default_extension' => env('DISCORD_EXTENSION_DEFAULT', 'png'),
-        'allow_gif_avatars' => (bool)env('DISCORD_AVATAR_GIF', true),
-        'client_id' => env('DISCORD_CLIENT_ID'),
-        'client_secret' => env('DISCORD_CLIENT_SECRET'),
-        'redirect' => env('APP_URL') . '/discord/callback',
-        'token' => env('DISCORD_TOKEN'),
+    |--------------------------------------------------------------------------
+    | Third Party Services
+    |--------------------------------------------------------------------------
+    |
+    | This file is for storing the credentials for third party services such
+    | as Mailgun, Postmark, AWS and more. This file provides the de facto
+    | location for this type of information, allowing packages to have
+    | a conventional file to locate the various service credentials.
+    |
+    */
+
+    'postmark' => [
+        'token' => env('POSTMARK_TOKEN'),
     ],
-    'google' => [
-        'client_id' => env('GOOGLE_CLIENT_ID'),
-        'client_secret' => env('GOOGLE_CLIENT_SECRET'),
-        'redirect' => env('APP_URL') . '/google/callback',
+
+    'ses' => [
+        'key' => env('AWS_ACCESS_KEY_ID'),
+        'secret' => env('AWS_SECRET_ACCESS_KEY'),
+        'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
+
+    'resend' => [
+        'key' => env('RESEND_KEY'),
+    ],
+
     'slack' => [
-        'bot_token' => env('SLACK_TOKEN'),
-        'client_id' => env('SLACK_CLIENT_ID'),
-        'client_secret' => env('SLACK_CLIENT_SECRET'),
-        'redirect' => env('APP_URL') . '/slack/callback',
+        'notifications' => [
+            'bot_user_oauth_token' => env('SLACK_BOT_USER_OAUTH_TOKEN'),
+            'channel' => env('SLACK_BOT_USER_DEFAULT_CHANNEL'),
+        ],
     ],
+
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -30,7 +30,26 @@ return [
         'key' => env('RESEND_KEY'),
     ],
 
+    'discord' => [
+        'avatar_default_extension' => env('DISCORD_EXTENSION_DEFAULT', 'png'),
+        'allow_gif_avatars' => (bool)env('DISCORD_AVATAR_GIF', true),
+        'client_id' => env('DISCORD_CLIENT_ID'),
+        'client_secret' => env('DISCORD_CLIENT_SECRET'),
+        'redirect' => env('APP_URL') . '/discord/callback',
+        'token' => env('DISCORD_TOKEN'),
+    ],
+
+    'google' => [
+        'client_id' => env('GOOGLE_CLIENT_ID'),
+        'client_secret' => env('GOOGLE_CLIENT_SECRET'),
+        'redirect' => env('APP_URL') . '/google/callback',
+    ],
+
     'slack' => [
+        'bot_token' => env('SLACK_TOKEN'),
+        'client_id' => env('SLACK_CLIENT_ID'),
+        'client_secret' => env('SLACK_CLIENT_SECRET'),
+        'redirect' => env('APP_URL') . '/slack/callback',
         'notifications' => [
             'bot_user_oauth_token' => env('SLACK_BOT_USER_OAUTH_TOKEN'),
             'channel' => env('SLACK_BOT_USER_DEFAULT_CHANNEL'),

--- a/config/session.php
+++ b/config/session.php
@@ -5,140 +5,215 @@ declare(strict_types=1);
 use Illuminate\Support\Str;
 
 return [
-    /*
-     * Default Session Driver
-     *
-     * This option controls the default session "driver" that will be used on
-     * requests. By default, we will use the lightweight native driver but you
-     * may specify any of the other wonderful drivers provided here.
-     *
-     * Supported: "file", "cookie", "database", "apc", "memcached", "redis",
-     * "dynamodb", "array"
-     */
-    'driver' => env('SESSION_DRIVER', 'file'),
 
     /*
-     * Session Lifetime
-     *
-     * Here you may specify the number of minutes that you wish the session to
-     * be allowed to remain idle before it expires. If you want them to
-     * immediately expire on the browser closing, set that option.
-     */
-    'lifetime' => env('SESSION_LIFETIME', 120),
-    'expire_on_close' => false,
+    |--------------------------------------------------------------------------
+    | Default Session Driver
+    |--------------------------------------------------------------------------
+    |
+    | This option determines the default session driver that is utilized for
+    | incoming requests. Laravel supports a variety of storage options to
+    | persist session data. Database storage is a great default choice.
+    |
+    | Supported: "file", "cookie", "database", "apc",
+    |            "memcached", "redis", "dynamodb", "array"
+    |
+    */
+
+    'driver' => env('SESSION_DRIVER', 'database'),
 
     /*
-     * Session Encryption
-     *
-     * This option allows you to easily specify that all of your session data
-     * should be encrypted before it is stored. All encryption will be run
-     * automatically by Laravel and you can use the Session like normal.
-     */
-    'encrypt' => false,
+    |--------------------------------------------------------------------------
+    | Session Lifetime
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the number of minutes that you wish the session
+    | to be allowed to remain idle before it expires. If you want them
+    | to expire immediately when the browser is closed then you may
+    | indicate that via the expire_on_close configuration option.
+    |
+    */
+
+    'lifetime' => (int) env('SESSION_LIFETIME', 120),
+
+    'expire_on_close' => env('SESSION_EXPIRE_ON_CLOSE', false),
 
     /*
-     * Session File Location
-     *
-     * When using the native session driver, we need a location where session
-     * files may be stored. A default has been set for you but a different
-     * location may be specified. This is only needed for file sessions.
-     */
+    |--------------------------------------------------------------------------
+    | Session Encryption
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to easily specify that all of your session data
+    | should be encrypted before it's stored. All encryption is performed
+    | automatically by Laravel and you may use the session like normal.
+    |
+    */
+
+    'encrypt' => env('SESSION_ENCRYPT', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Session File Location
+    |--------------------------------------------------------------------------
+    |
+    | When utilizing the "file" session driver, the session files are placed
+    | on disk. The default storage location is defined here; however, you
+    | are free to provide another location where they should be stored.
+    |
+    */
+
     'files' => storage_path('framework/sessions'),
 
     /*
-     * Session Database Connection
-     *
-     * When using the "database" or "redis" session drivers, you may specify a
-     * connection that should be used to manage these sessions. This should
-     * correspond to a connection in your database configuration options.
-     */
-    'connection' => env('SESSION_CONNECTION', null),
+    |--------------------------------------------------------------------------
+    | Session Database Connection
+    |--------------------------------------------------------------------------
+    |
+    | When using the "database" or "redis" session drivers, you may specify a
+    | connection that should be used to manage these sessions. This should
+    | correspond to a connection in your database configuration options.
+    |
+    */
+
+    'connection' => env('SESSION_CONNECTION'),
 
     /*
-     * Session Database Table
-     *
-     * When using the "database" session driver, you may specify the table we
-     * should use to manage the sessions. Of course, a sensible default is
-     * provided for you; however, you are free to change this as needed.
-     */
-    'table' => 'sessions',
+    |--------------------------------------------------------------------------
+    | Session Database Table
+    |--------------------------------------------------------------------------
+    |
+    | When using the "database" session driver, you may specify the table to
+    | be used to store sessions. Of course, a sensible default is defined
+    | for you; however, you're welcome to change this to another table.
+    |
+    */
+
+    'table' => env('SESSION_TABLE', 'sessions'),
 
     /*
-     * Session Cache Store
-     *
-     * While using one of the framework's cache driven session backends you may
-     * list a cache store that should be used for these sessions. This value
-     * must match with one of the application's configured cache "stores".
-     *
-     * Affects: "apc", "dynamodb", "memcached", "redis"
-     */
-    'store' => env('SESSION_STORE', null),
+    |--------------------------------------------------------------------------
+    | Session Cache Store
+    |--------------------------------------------------------------------------
+    |
+    | When using one of the framework's cache driven session backends, you may
+    | define the cache store which should be used to store the session data
+    | between requests. This must match one of your defined cache stores.
+    |
+    | Affects: "apc", "dynamodb", "memcached", "redis"
+    |
+    */
+
+    'store' => env('SESSION_STORE'),
 
     /*
-     * Session Sweeping Lottery
-     *
-     * Some session drivers must manually sweep their storage location to get
-     * rid of old sessions from storage. Here are the chances that it will
-     * happen on a given request. By default, the odds are 2 out of 100.
-     */
+    |--------------------------------------------------------------------------
+    | Session Sweeping Lottery
+    |--------------------------------------------------------------------------
+    |
+    | Some session drivers must manually sweep their storage location to get
+    | rid of old sessions from storage. Here are the chances that it will
+    | happen on a given request. By default, the odds are 2 out of 100.
+    |
+    */
+
     'lottery' => [2, 100],
 
     /*
-     * Session Cookie Name
-     *
-     * Here you may change the name of the cookie used to identify a session
-     * instance by ID. The name specified here will get used every time a new
-     * session cookie is created by the framework for every driver.
-     */
+    |--------------------------------------------------------------------------
+    | Session Cookie Name
+    |--------------------------------------------------------------------------
+    |
+    | Here you may change the name of the session cookie that is created by
+    | the framework. Typically, you should not need to change this value
+    | since doing so does not grant a meaningful security improvement.
+    |
+    */
+
     'cookie' => env(
         'SESSION_COOKIE',
         Str::slug(env('APP_NAME', 'laravel'), '_') . '_session'
     ),
 
     /*
-     * Session Cookie Path
-     *
-     * The session cookie path determines the path for which the cookie will
-     * be regarded as available. Typically, this will be the root path of
-     * your application but you are free to change this when necessary.
-     */
-    'path' => '/',
+    |--------------------------------------------------------------------------
+    | Session Cookie Path
+    |--------------------------------------------------------------------------
+    |
+    | The session cookie path determines the path for which the cookie will
+    | be regarded as available. Typically, this will be the root path of
+    | your application, but you're free to change this when necessary.
+    |
+    */
+
+    'path' => env('SESSION_PATH', '/'),
 
     /*
-     * Session Cookie Domain
-     *
-     * Here you may change the domain of the cookie used to identify a session
-     * in your application. This will determine which domains the cookie is
-     * available to in your application. A sensible default has been set.
-     */
-    'domain' => env('SESSION_DOMAIN', null),
+    |--------------------------------------------------------------------------
+    | Session Cookie Domain
+    |--------------------------------------------------------------------------
+    |
+    | This value determines the domain and subdomains the session cookie is
+    | available to. By default, the cookie will be available to the root
+    | domain and all subdomains. Typically, this shouldn't be changed.
+    |
+    */
+
+    'domain' => env('SESSION_DOMAIN'),
 
     /*
-     * HTTPS Only Cookies
-     *
-     * By setting this option to true, session cookies will only be sent back
-     * to the server if the browser has a HTTPS connection. This will keep
-     * the cookie from being sent to you if it can not be done securely.
-     */
-    'secure' => env('SESSION_SECURE_COOKIE', true),
+    |--------------------------------------------------------------------------
+    | HTTPS Only Cookies
+    |--------------------------------------------------------------------------
+    |
+    | By setting this option to true, session cookies will only be sent back
+    | to the server if the browser has a HTTPS connection. This will keep
+    | the cookie from being sent to you when it can't be done securely.
+    |
+    */
+
+    'secure' => env('SESSION_SECURE_COOKIE'),
 
     /*
-     * HTTP Access Only
-     *
-     * Setting this value to true will prevent JavaScript from accessing the
-     * value of the cookie and the cookie will only be accessible through
-     * the HTTP protocol. You are free to modify this option if needed.
-     */
-    'http_only' => true,
+    |--------------------------------------------------------------------------
+    | HTTP Access Only
+    |--------------------------------------------------------------------------
+    |
+    | Setting this value to true will prevent JavaScript from accessing the
+    | value of the cookie and the cookie will only be accessible through
+    | the HTTP protocol. It's unlikely you should disable this option.
+    |
+    */
+
+    'http_only' => env('SESSION_HTTP_ONLY', true),
 
     /*
-     * Same-Site Cookies
-     *
-     * This option determines how your cookies behave when cross-site requests
-     * take place, and can be used to mitigate CSRF attacks. By default, we
-     * will set this value to "lax" since this is a secure default value.
-     *
-     * Supported: "lax", "strict", "none", null
-     */
-    'same_site' => 'lax',
+    |--------------------------------------------------------------------------
+    | Same-Site Cookies
+    |--------------------------------------------------------------------------
+    |
+    | This option determines how your cookies behave when cross-site requests
+    | take place, and can be used to mitigate CSRF attacks. By default, we
+    | will set this value to "lax" to permit secure cross-site requests.
+    |
+    | See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value
+    |
+    | Supported: "lax", "strict", "none", null
+    |
+    */
+
+    'same_site' => env('SESSION_SAME_SITE', 'lax'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Partitioned Cookies
+    |--------------------------------------------------------------------------
+    |
+    | Setting this value to true will tie the cookie to the top-level site for
+    | a cross-site context. Partitioned cookies are accepted by the browser
+    | when flagged "secure" and the Same-Site attribute is set to "none".
+    |
+    */
+
+    'partitioned' => env('SESSION_PARTITIONED_COOKIE', false),
+
 ];

--- a/config/view.php
+++ b/config/view.php
@@ -3,26 +3,36 @@
 declare(strict_types=1);
 
 return [
+
     /*
-     * View Storage Paths
-     *
-     * Most templating systems load templates from disk. Here you may specify an
-     * array of paths that should be checked for your views. Of course the usual
-     * Laravel view path has already been registered for you.
-     */
+    |--------------------------------------------------------------------------
+    | View Storage Paths
+    |--------------------------------------------------------------------------
+    |
+    | Most templating systems load templates from disk. Here you may specify
+    | an array of paths that should be checked for your views. Of course
+    | the usual Laravel view path has already been registered for you.
+    |
+    */
+
     'paths' => [
         resource_path('views'),
     ],
 
     /*
-     * Compiled View Path
-     *
-     * This option determines where all the compiled Blade templates will be
-     * stored for your application. Typically, this is within the storage
-     * directory. However, as usual, you are free to change this value.
-     */
+    |--------------------------------------------------------------------------
+    | Compiled View Path
+    |--------------------------------------------------------------------------
+    |
+    | This option determines where all the compiled Blade templates will be
+    | stored for your application. Typically, this is within the storage
+    | directory. However, as usual, you are free to change this value.
+    |
+    */
+
     'compiled' => env(
         'VIEW_COMPILED_PATH',
         realpath(storage_path('framework/views'))
     ),
+
 ];

--- a/database/factories/CampaignFactory.php
+++ b/database/factories/CampaignFactory.php
@@ -15,8 +15,6 @@ use function array_keys;
  */
 class CampaignFactory extends Factory
 {
-    protected $model = Campaign::class;
-
     /**
      * Define the model's default state.
      * @return array<string, mixed>

--- a/database/factories/ChannelFactory.php
+++ b/database/factories/ChannelFactory.php
@@ -16,8 +16,6 @@ use function array_keys;
  */
 class ChannelFactory extends Factory
 {
-    protected $model = Channel::class;
-
     /**
      * Define the model's default state.
      * @return array<string, int|null|string>

--- a/database/factories/CharacterFactory.php
+++ b/database/factories/CharacterFactory.php
@@ -18,8 +18,6 @@ use function in_array;
  */
 class CharacterFactory extends Factory
 {
-    protected $model = Character::class;
-
     /**
      * List of systems that use 'handle' instead of 'name' to describe the
      * character.

--- a/database/factories/ChatCharacterFactory.php
+++ b/database/factories/ChatCharacterFactory.php
@@ -14,8 +14,6 @@ use Illuminate\Database\Eloquent\Factories\Factory;
  */
 class ChatCharacterFactory extends Factory
 {
-    protected $model = ChatCharacter::class;
-
     /**
      * Define the model's default state.
      * @return array<string, int>

--- a/database/factories/ChatUserFactory.php
+++ b/database/factories/ChatUserFactory.php
@@ -14,8 +14,6 @@ use Illuminate\Support\Str;
  */
 class ChatUserFactory extends Factory
 {
-    protected $model = ChatUser::class;
-
     /**
      * Define the model's default state.
      * @return array<string, bool|int|string>

--- a/database/factories/EventFactory.php
+++ b/database/factories/EventFactory.php
@@ -14,8 +14,6 @@ use Illuminate\Database\Eloquent\Factories\Factory;
  */
 class EventFactory extends Factory
 {
-    protected $model = Event::class;
-
     /**
      * @return array<string, int|null|string>
      */

--- a/database/factories/InitiativeFactory.php
+++ b/database/factories/InitiativeFactory.php
@@ -12,8 +12,6 @@ use Illuminate\Database\Eloquent\Factories\Factory;
  */
 class InitiativeFactory extends Factory
 {
-    protected $model = Initiative::class;
-
     /**
      * Define the model's default state.
      * @return array<string, int|null|string>

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -15,8 +15,6 @@ use Spatie\Permission\Models\Role;
  */
 class UserFactory extends Factory
 {
-    protected $model = User::class;
-
     public function definition(): array
     {
         return [

--- a/stubs/Modules/factory.stub
+++ b/stubs/Modules/factory.stub
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace $NAMESPACE$;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use $MODEL_NAMESPACE$\$NAME$;
 
 class $NAME$Factory extends Factory
 {
     /**
      * The name of the factory's corresponding model.
      */
-    protected $model = \$MODEL_NAMESPACE$\$NAME$::class;
+    protected $model = $NAME$::class;
 
     /**
      * Define the model's default state.

--- a/stubs/factory.stub
+++ b/stubs/factory.stub
@@ -10,12 +10,6 @@ use {{ namespacedModel }};
 class {{ factory }}Factory extends Factory
 {
     /**
-     * The name of the factory's corresponding model.
-     * @var string
-     */
-    protected $model = {{ model }}::class;
-
-    /**
      * Define the model's default state.
      * @return array<string, mixed>
      */


### PR DESCRIPTION
Apply some suggestions from the Laravel Linter:
* Cleaned up config files. I had originally cleaned up the comments from the ugly default to look like the rest, but that makes upgrading more difficult.
* Removed the `$model` property from base database factories. Note that module factories still need the property set to work.